### PR TITLE
Optimiser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,47 +9,47 @@
       "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
-        "parsing": "^2.2.0",
+        "parsing": "^2.3.0",
         "transpiler": "^1.2.0"
       },
       "devDependencies": {
         "@types/chai": "^4.3.1",
         "@types/mocha": "^9.1.1",
-        "@types/node": "^17.0.29",
-        "@typescript-eslint/eslint-plugin": "^5.21.0",
-        "@typescript-eslint/parser": "^5.21.0",
+        "@types/node": "^17.0.34",
+        "@typescript-eslint/eslint-plugin": "^5.25.0",
+        "@typescript-eslint/parser": "^5.25.0",
         "chai": "^4.3.6",
         "chai-as-promised": "^7.1.1",
-        "eslint": "^8.14.0",
+        "eslint": "^8.15.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-prettier": "^4.0.0",
-        "mocha": "^9.2.2",
-        "mocha-bootstrap": "^1.0.2",
+        "mocha": "^10.0.0",
+        "mocha-bootstrap": "^1.0.3",
         "prettier": "^2.6.2",
-        "sinon": "^13.0.2",
+        "sinon": "^14.0.0",
         "sinon-chai": "^3.7.0",
-        "ts-mocha": "^9.0.2",
+        "ts-mocha": "^10.0.0",
         "ts-sinon": "^2.0.2",
-        "typescript": "^4.6.3"
+        "typescript": "^4.6.4"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.2.tgz",
-      "integrity": "sha512-lTVWHs7O2hjBFZunXTZYnYqtB9GakA1lnxIf+gKq2nY5gxkkNi/lQvveW6t8gFdOHTg6nG50Xs95PrLqVpcaLg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.3.tgz",
+      "integrity": "sha512-uGo44hIwoLGNyduRpjdEpovcbMdd+Nv7amtmJxnKmI8xj6yd5LncmSwDa5NgX/41lIFJtkjD6YdVfgEzPfJ5UA==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.3.1",
+        "espree": "^9.3.2",
         "globals": "^13.9.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -161,7 +161,7 @@
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "optional": true
     },
@@ -172,9 +172,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.31",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.31.tgz",
-      "integrity": "sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q==",
+      "version": "17.0.34",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.34.tgz",
+      "integrity": "sha512-XImEz7XwTvDBtzlTnm8YvMqGW/ErMWBsKZ+hMTvnDIjGCKxwK5Xpc+c/oQjOauwq8M4OS11hEkpjX8rrI/eEgA==",
       "dev": true
     },
     "node_modules/@types/sinon": {
@@ -203,19 +203,19 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.22.0.tgz",
-      "integrity": "sha512-YCiy5PUzpAeOPGQ7VSGDEY2NeYUV1B0swde2e0HzokRsHBYjSdF6DZ51OuRZxVPHx0032lXGLvOMls91D8FXlg==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.25.0.tgz",
+      "integrity": "sha512-icYrFnUzvm+LhW0QeJNKkezBu6tJs9p/53dpPLFH8zoM9w1tfaKzVurkPotEpAqQ8Vf8uaFyL5jHd0Vs6Z0ZQg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.22.0",
-        "@typescript-eslint/type-utils": "5.22.0",
-        "@typescript-eslint/utils": "5.22.0",
-        "debug": "^4.3.2",
+        "@typescript-eslint/scope-manager": "5.25.0",
+        "@typescript-eslint/type-utils": "5.25.0",
+        "@typescript-eslint/utils": "5.25.0",
+        "debug": "^4.3.4",
         "functional-red-black-tree": "^1.0.1",
-        "ignore": "^5.1.8",
+        "ignore": "^5.2.0",
         "regexpp": "^3.2.0",
-        "semver": "^7.3.5",
+        "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       },
       "engines": {
@@ -236,15 +236,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.22.0.tgz",
-      "integrity": "sha512-piwC4krUpRDqPaPbFaycN70KCP87+PC5WZmrWs+DlVOxxmF+zI6b6hETv7Quy4s9wbkV16ikMeZgXsvzwI3icQ==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.25.0.tgz",
+      "integrity": "sha512-r3hwrOWYbNKP1nTcIw/aZoH+8bBnh/Lh1iDHoFpyG4DnCpvEdctrSl6LOo19fZbzypjQMHdajolxs6VpYoChgA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.22.0",
-        "@typescript-eslint/types": "5.22.0",
-        "@typescript-eslint/typescript-estree": "5.22.0",
-        "debug": "^4.3.2"
+        "@typescript-eslint/scope-manager": "5.25.0",
+        "@typescript-eslint/types": "5.25.0",
+        "@typescript-eslint/typescript-estree": "5.25.0",
+        "debug": "^4.3.4"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -263,13 +263,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.22.0.tgz",
-      "integrity": "sha512-yA9G5NJgV5esANJCO0oF15MkBO20mIskbZ8ijfmlKIvQKg0ynVKfHZ15/nhAJN5m8Jn3X5qkwriQCiUntC9AbA==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.25.0.tgz",
+      "integrity": "sha512-p4SKTFWj+2VpreUZ5xMQsBMDdQ9XdRvODKXN4EksyBjFp2YvQdLkyHqOffakYZPuWJUDNu3jVXtHALDyTv3cww==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.22.0",
-        "@typescript-eslint/visitor-keys": "5.22.0"
+        "@typescript-eslint/types": "5.25.0",
+        "@typescript-eslint/visitor-keys": "5.25.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -280,13 +280,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.22.0.tgz",
-      "integrity": "sha512-iqfLZIsZhK2OEJ4cQ01xOq3NaCuG5FQRKyHicA3xhZxMgaxQazLUHbH/B2k9y5i7l3+o+B5ND9Mf1AWETeMISA==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.25.0.tgz",
+      "integrity": "sha512-B6nb3GK3Gv1Rsb2pqalebe/RyQoyG/WDy9yhj8EE0Ikds4Xa8RR28nHz+wlt4tMZk5bnAr0f3oC8TuDAd5CPrw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/utils": "5.22.0",
-        "debug": "^4.3.2",
+        "@typescript-eslint/utils": "5.25.0",
+        "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
       "engines": {
@@ -306,9 +306,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.22.0.tgz",
-      "integrity": "sha512-T7owcXW4l0v7NTijmjGWwWf/1JqdlWiBzPqzAWhobxft0SiEvMJB56QXmeCQjrPuM8zEfGUKyPQr/L8+cFUBLw==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.25.0.tgz",
+      "integrity": "sha512-7fWqfxr0KNHj75PFqlGX24gWjdV/FDBABXL5dyvBOWHpACGyveok8Uj4ipPX/1fGU63fBkzSIycEje4XsOxUFA==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -319,17 +319,17 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.22.0.tgz",
-      "integrity": "sha512-EyBEQxvNjg80yinGE2xdhpDYm41so/1kOItl0qrjIiJ1kX/L/L8WWGmJg8ni6eG3DwqmOzDqOhe6763bF92nOw==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.25.0.tgz",
+      "integrity": "sha512-MrPODKDych/oWs/71LCnuO7NyR681HuBly2uLnX3r5i4ME7q/yBqC4hW33kmxtuauLTM0OuBOhhkFaxCCOjEEw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.22.0",
-        "@typescript-eslint/visitor-keys": "5.22.0",
-        "debug": "^4.3.2",
-        "globby": "^11.0.4",
+        "@typescript-eslint/types": "5.25.0",
+        "@typescript-eslint/visitor-keys": "5.25.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
         "is-glob": "^4.0.3",
-        "semver": "^7.3.5",
+        "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       },
       "engines": {
@@ -346,15 +346,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.22.0.tgz",
-      "integrity": "sha512-HodsGb037iobrWSUMS7QH6Hl1kppikjA1ELiJlNSTYf/UdMEwzgj0WIp+lBNb6WZ3zTwb0tEz51j0Wee3iJ3wQ==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.25.0.tgz",
+      "integrity": "sha512-qNC9bhnz/n9Kba3yI6HQgQdBLuxDoMgdjzdhSInZh6NaDnFpTUlwNGxplUFWfY260Ya0TRPvkg9dd57qxrJI9g==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.22.0",
-        "@typescript-eslint/types": "5.22.0",
-        "@typescript-eslint/typescript-estree": "5.22.0",
+        "@typescript-eslint/scope-manager": "5.25.0",
+        "@typescript-eslint/types": "5.25.0",
+        "@typescript-eslint/typescript-estree": "5.25.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -370,13 +370,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.22.0.tgz",
-      "integrity": "sha512-DbgTqn2Dv5RFWluG88tn0pP6Ex0ROF+dpDO1TNNZdRtLjUr6bdznjA6f/qNqJLjd2PgguAES2Zgxh/JzwzETDg==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.25.0.tgz",
+      "integrity": "sha512-yd26vFgMsC4h2dgX4+LR+GeicSKIfUvZREFLf3DDjZPtqgLx5AJZr6TetMNwFP9hcKreTTeztQYBTNbNoOycwA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.22.0",
-        "eslint-visitor-keys": "^3.0.0"
+        "@typescript-eslint/types": "5.25.0",
+        "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -493,7 +493,7 @@
     "node_modules/arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -627,7 +627,7 @@
     "node_modules/check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
       "dev": true,
       "engines": {
         "node": "*"
@@ -829,12 +829,12 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.14.0.tgz",
-      "integrity": "sha512-3/CE4aJX7LNEiE3i6FeodHmI/38GZtWCsAtsymScmzYapx8q1nVVb+eLcLSzATmCPXw5pT4TqVs1E0OmxAd9tw==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.15.0.tgz",
+      "integrity": "sha512-GG5USZ1jhCu8HJkzGgeK8/+RGnHaNYZGrGDzUtigK3BsGESW/rs2az23XqE0WVwDxy1VRvvjSSGu5nB0Bu+6SA==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.2.2",
+        "@eslint/eslintrc": "^1.2.3",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -845,7 +845,7 @@
         "eslint-scope": "^7.1.1",
         "eslint-utils": "^3.0.0",
         "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.3.1",
+        "espree": "^9.3.2",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -861,7 +861,7 @@
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
         "regexpp": "^3.2.0",
@@ -985,13 +985,13 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
-      "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.2.tgz",
+      "integrity": "sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==",
       "dev": true,
       "dependencies": {
-        "acorn": "^8.7.0",
-        "acorn-jsx": "^5.3.1",
+        "acorn": "^8.7.1",
+        "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -1264,9 +1264,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.13.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
-      "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
+      "version": "13.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.15.0.tgz",
+      "integrity": "sha512-bpzcOlgDhMG070Av0Vy5Owklpv1I6+j96GhUI7Rh7IzDCKLzboflLrrfqMu8NquDbiR4EOQk7XzJwqVJxicxog==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -1296,15 +1296,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/growl": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.x"
       }
     },
     "node_modules/has-flag": {
@@ -1646,42 +1637,40 @@
       }
     },
     "node_modules/mocha": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
-      "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.0.0.tgz",
+      "integrity": "sha512-0Wl+elVUD43Y0BqPZBzZt8Tnkw9CMUdNYnUsTfOM1vuhJVZL+kiesFYsqwBkEEuEixaiPe5ZQdqDgX2jddhmoA==",
       "dev": true,
       "dependencies": {
         "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
         "chokidar": "3.5.3",
-        "debug": "4.3.3",
+        "debug": "4.3.4",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
         "glob": "7.2.0",
-        "growl": "1.10.5",
         "he": "1.2.0",
         "js-yaml": "4.1.0",
         "log-symbols": "4.1.0",
-        "minimatch": "4.2.1",
+        "minimatch": "5.0.1",
         "ms": "2.1.3",
-        "nanoid": "3.3.1",
+        "nanoid": "3.3.3",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
-        "which": "2.0.2",
-        "workerpool": "6.2.0",
+        "workerpool": "6.2.1",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
         "yargs-unparser": "2.0.0"
       },
       "bin": {
         "_mocha": "bin/_mocha",
-        "mocha": "bin/mocha"
+        "mocha": "bin/mocha.js"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 14.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1689,9 +1678,9 @@
       }
     },
     "node_modules/mocha-bootstrap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/mocha-bootstrap/-/mocha-bootstrap-1.0.2.tgz",
-      "integrity": "sha512-83CS/7t7lHxz4njHI4apUmGlVO4C74vSs8eX4ZUMhQLStUry/fkfS5NdGhNtnbZO73P28xHx8r4Q2Gv9b2zHlQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/mocha-bootstrap/-/mocha-bootstrap-1.0.3.tgz",
+      "integrity": "sha512-8DNjgTvN8904ZnFV9RlpB/rxeaI+sU07sm8/pTR0pJCguwUjvodQ78j5nW8aNUYKshF2OwkEeqn1MZX+58m93g==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -1699,41 +1688,27 @@
       "peerDependencies": {
         "chai": "^4.3.6",
         "chai-as-promised": "^7.1.1",
-        "mocha": "^9.2.2",
-        "sinon": "^13.0.1",
+        "mocha": "^10.0.0",
+        "sinon": "^14.0.0",
         "sinon-chai": "^3.7.0"
       }
     },
-    "node_modules/mocha/node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+    "node_modules/mocha/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
       "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
+        "balanced-match": "^1.0.0"
       }
     },
-    "node_modules/mocha/node_modules/debug/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
     "node_modules/mocha/node_modules/minimatch": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
-      "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
       "dev": true,
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
         "node": ">=10"
@@ -1767,9 +1742,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
-      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
       "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -1875,11 +1850,11 @@
       }
     },
     "node_modules/parsing": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/parsing/-/parsing-2.2.0.tgz",
-      "integrity": "sha512-T81oF74Ug3cdfoHMD428oxi9OALgfI+d/dpfy8ymK60dTAyQByNixEoQOtKwO0CC5t683dX4BzKWH5mUcQ4U5Q==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/parsing/-/parsing-2.3.0.tgz",
+      "integrity": "sha512-9KFnyd1tFJy1ocwgcd7aYlYo+huI1FKuxvpO48yTvjyweB6qm4oQDP9oUOaJaybY6iS9UY0tds9tTJgRmeyyPQ==",
       "dependencies": {
-        "microdash": "^1.4.0"
+        "microdash": "^1.4.2"
       },
       "engines": {
         "node": ">=0.6"
@@ -2181,9 +2156,9 @@
       }
     },
     "node_modules/sinon": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-13.0.2.tgz",
-      "integrity": "sha512-KvOrztAVqzSJWMDoxM4vM+GPys1df2VBoXm+YciyB/OLMamfS3VXh3oGh5WtrAGSzrgczNWFFY22oKb7Fi5eeA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-14.0.0.tgz",
+      "integrity": "sha512-ugA6BFmE+WrJdh0owRZHToLd32Uw3Lxq6E6LtNRU+xTVBefx632h03Q7apXWRsRdZAJ41LB8aUfn2+O4jsDNMw==",
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.8.3",
@@ -2335,9 +2310,9 @@
       }
     },
     "node_modules/ts-mocha": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/ts-mocha/-/ts-mocha-9.0.2.tgz",
-      "integrity": "sha512-WyQjvnzwrrubl0JT7EC1yWmNpcsU3fOuBFfdps30zbmFBgKniSaSOyZMZx+Wq7kytUs5CY+pEbSYEbGfIKnXTw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/ts-mocha/-/ts-mocha-10.0.0.tgz",
+      "integrity": "sha512-VRfgDO+iiuJFlNB18tzOfypJ21xn2xbuZyDvJvqpTbWgkAgD17ONGr8t+Tl8rcBtOBdjXp5e/Rk+d39f7XBHRw==",
       "dev": true,
       "dependencies": {
         "ts-node": "7.0.1"
@@ -2352,7 +2327,7 @@
         "tsconfig-paths": "^3.5.0"
       },
       "peerDependencies": {
-        "mocha": "^3.X.X || ^4.X.X || ^5.X.X || ^6.X.X || ^7.X.X || ^8.X.X || ^9.X.X"
+        "mocha": "^3.X.X || ^4.X.X || ^5.X.X || ^6.X.X || ^7.X.X || ^8.X.X || ^9.X.X || ^10.X.X"
       }
     },
     "node_modules/ts-node": {
@@ -2419,9 +2394,9 @@
       }
     },
     "node_modules/ts-sinon/node_modules/@types/node": {
-      "version": "14.18.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.16.tgz",
-      "integrity": "sha512-X3bUMdK/VmvrWdoTkz+VCn6nwKwrKCFTHtqwBIaQJNx4RUIBBUFXM00bqPz/DsDd+Icjmzm6/tyYZzeGVqb6/Q==",
+      "version": "14.18.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.18.tgz",
+      "integrity": "sha512-B9EoJFjhqcQ9OmQrNorItO+OwEOORNn3S31WuiHvZY/dm9ajkB7AKD/8toessEtHHNL+58jofbq7hMMY9v4yig==",
       "dev": true
     },
     "node_modules/ts-sinon/node_modules/diff": {
@@ -2584,9 +2559,9 @@
       }
     },
     "node_modules/workerpool": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
-      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
+      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
       "dev": true
     },
     "node_modules/wrap-ansi": {
@@ -2693,19 +2668,19 @@
   },
   "dependencies": {
     "@eslint/eslintrc": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.2.tgz",
-      "integrity": "sha512-lTVWHs7O2hjBFZunXTZYnYqtB9GakA1lnxIf+gKq2nY5gxkkNi/lQvveW6t8gFdOHTg6nG50Xs95PrLqVpcaLg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.3.tgz",
+      "integrity": "sha512-uGo44hIwoLGNyduRpjdEpovcbMdd+Nv7amtmJxnKmI8xj6yd5LncmSwDa5NgX/41lIFJtkjD6YdVfgEzPfJ5UA==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.3.1",
+        "espree": "^9.3.2",
         "globals": "^13.9.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       }
     },
@@ -2802,7 +2777,7 @@
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "optional": true
     },
@@ -2813,9 +2788,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.31",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.31.tgz",
-      "integrity": "sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q==",
+      "version": "17.0.34",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.34.tgz",
+      "integrity": "sha512-XImEz7XwTvDBtzlTnm8YvMqGW/ErMWBsKZ+hMTvnDIjGCKxwK5Xpc+c/oQjOauwq8M4OS11hEkpjX8rrI/eEgA==",
       "dev": true
     },
     "@types/sinon": {
@@ -2844,98 +2819,98 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.22.0.tgz",
-      "integrity": "sha512-YCiy5PUzpAeOPGQ7VSGDEY2NeYUV1B0swde2e0HzokRsHBYjSdF6DZ51OuRZxVPHx0032lXGLvOMls91D8FXlg==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.25.0.tgz",
+      "integrity": "sha512-icYrFnUzvm+LhW0QeJNKkezBu6tJs9p/53dpPLFH8zoM9w1tfaKzVurkPotEpAqQ8Vf8uaFyL5jHd0Vs6Z0ZQg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.22.0",
-        "@typescript-eslint/type-utils": "5.22.0",
-        "@typescript-eslint/utils": "5.22.0",
-        "debug": "^4.3.2",
+        "@typescript-eslint/scope-manager": "5.25.0",
+        "@typescript-eslint/type-utils": "5.25.0",
+        "@typescript-eslint/utils": "5.25.0",
+        "debug": "^4.3.4",
         "functional-red-black-tree": "^1.0.1",
-        "ignore": "^5.1.8",
+        "ignore": "^5.2.0",
         "regexpp": "^3.2.0",
-        "semver": "^7.3.5",
+        "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.22.0.tgz",
-      "integrity": "sha512-piwC4krUpRDqPaPbFaycN70KCP87+PC5WZmrWs+DlVOxxmF+zI6b6hETv7Quy4s9wbkV16ikMeZgXsvzwI3icQ==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.25.0.tgz",
+      "integrity": "sha512-r3hwrOWYbNKP1nTcIw/aZoH+8bBnh/Lh1iDHoFpyG4DnCpvEdctrSl6LOo19fZbzypjQMHdajolxs6VpYoChgA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.22.0",
-        "@typescript-eslint/types": "5.22.0",
-        "@typescript-eslint/typescript-estree": "5.22.0",
-        "debug": "^4.3.2"
+        "@typescript-eslint/scope-manager": "5.25.0",
+        "@typescript-eslint/types": "5.25.0",
+        "@typescript-eslint/typescript-estree": "5.25.0",
+        "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.22.0.tgz",
-      "integrity": "sha512-yA9G5NJgV5esANJCO0oF15MkBO20mIskbZ8ijfmlKIvQKg0ynVKfHZ15/nhAJN5m8Jn3X5qkwriQCiUntC9AbA==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.25.0.tgz",
+      "integrity": "sha512-p4SKTFWj+2VpreUZ5xMQsBMDdQ9XdRvODKXN4EksyBjFp2YvQdLkyHqOffakYZPuWJUDNu3jVXtHALDyTv3cww==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.22.0",
-        "@typescript-eslint/visitor-keys": "5.22.0"
+        "@typescript-eslint/types": "5.25.0",
+        "@typescript-eslint/visitor-keys": "5.25.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.22.0.tgz",
-      "integrity": "sha512-iqfLZIsZhK2OEJ4cQ01xOq3NaCuG5FQRKyHicA3xhZxMgaxQazLUHbH/B2k9y5i7l3+o+B5ND9Mf1AWETeMISA==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.25.0.tgz",
+      "integrity": "sha512-B6nb3GK3Gv1Rsb2pqalebe/RyQoyG/WDy9yhj8EE0Ikds4Xa8RR28nHz+wlt4tMZk5bnAr0f3oC8TuDAd5CPrw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/utils": "5.22.0",
-        "debug": "^4.3.2",
+        "@typescript-eslint/utils": "5.25.0",
+        "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.22.0.tgz",
-      "integrity": "sha512-T7owcXW4l0v7NTijmjGWwWf/1JqdlWiBzPqzAWhobxft0SiEvMJB56QXmeCQjrPuM8zEfGUKyPQr/L8+cFUBLw==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.25.0.tgz",
+      "integrity": "sha512-7fWqfxr0KNHj75PFqlGX24gWjdV/FDBABXL5dyvBOWHpACGyveok8Uj4ipPX/1fGU63fBkzSIycEje4XsOxUFA==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.22.0.tgz",
-      "integrity": "sha512-EyBEQxvNjg80yinGE2xdhpDYm41so/1kOItl0qrjIiJ1kX/L/L8WWGmJg8ni6eG3DwqmOzDqOhe6763bF92nOw==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.25.0.tgz",
+      "integrity": "sha512-MrPODKDych/oWs/71LCnuO7NyR681HuBly2uLnX3r5i4ME7q/yBqC4hW33kmxtuauLTM0OuBOhhkFaxCCOjEEw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.22.0",
-        "@typescript-eslint/visitor-keys": "5.22.0",
-        "debug": "^4.3.2",
-        "globby": "^11.0.4",
+        "@typescript-eslint/types": "5.25.0",
+        "@typescript-eslint/visitor-keys": "5.25.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
         "is-glob": "^4.0.3",
-        "semver": "^7.3.5",
+        "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.22.0.tgz",
-      "integrity": "sha512-HodsGb037iobrWSUMS7QH6Hl1kppikjA1ELiJlNSTYf/UdMEwzgj0WIp+lBNb6WZ3zTwb0tEz51j0Wee3iJ3wQ==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.25.0.tgz",
+      "integrity": "sha512-qNC9bhnz/n9Kba3yI6HQgQdBLuxDoMgdjzdhSInZh6NaDnFpTUlwNGxplUFWfY260Ya0TRPvkg9dd57qxrJI9g==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.22.0",
-        "@typescript-eslint/types": "5.22.0",
-        "@typescript-eslint/typescript-estree": "5.22.0",
+        "@typescript-eslint/scope-manager": "5.25.0",
+        "@typescript-eslint/types": "5.25.0",
+        "@typescript-eslint/typescript-estree": "5.25.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.22.0.tgz",
-      "integrity": "sha512-DbgTqn2Dv5RFWluG88tn0pP6Ex0ROF+dpDO1TNNZdRtLjUr6bdznjA6f/qNqJLjd2PgguAES2Zgxh/JzwzETDg==",
+      "version": "5.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.25.0.tgz",
+      "integrity": "sha512-yd26vFgMsC4h2dgX4+LR+GeicSKIfUvZREFLf3DDjZPtqgLx5AJZr6TetMNwFP9hcKreTTeztQYBTNbNoOycwA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.22.0",
-        "eslint-visitor-keys": "^3.0.0"
+        "@typescript-eslint/types": "5.25.0",
+        "eslint-visitor-keys": "^3.3.0"
       }
     },
     "@ungap/promise-all-settled": {
@@ -3015,7 +2990,7 @@
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
       "dev": true
     },
     "assertion-error": {
@@ -3116,7 +3091,7 @@
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
       "dev": true
     },
     "chokidar": {
@@ -3262,12 +3237,12 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.14.0.tgz",
-      "integrity": "sha512-3/CE4aJX7LNEiE3i6FeodHmI/38GZtWCsAtsymScmzYapx8q1nVVb+eLcLSzATmCPXw5pT4TqVs1E0OmxAd9tw==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.15.0.tgz",
+      "integrity": "sha512-GG5USZ1jhCu8HJkzGgeK8/+RGnHaNYZGrGDzUtigK3BsGESW/rs2az23XqE0WVwDxy1VRvvjSSGu5nB0Bu+6SA==",
       "dev": true,
       "requires": {
-        "@eslint/eslintrc": "^1.2.2",
+        "@eslint/eslintrc": "^1.2.3",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -3278,7 +3253,7 @@
         "eslint-scope": "^7.1.1",
         "eslint-utils": "^3.0.0",
         "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.3.1",
+        "espree": "^9.3.2",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -3294,7 +3269,7 @@
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
         "regexpp": "^3.2.0",
@@ -3372,13 +3347,13 @@
       "dev": true
     },
     "espree": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
-      "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.2.tgz",
+      "integrity": "sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==",
       "dev": true,
       "requires": {
-        "acorn": "^8.7.0",
-        "acorn-jsx": "^5.3.1",
+        "acorn": "^8.7.1",
+        "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^3.3.0"
       }
     },
@@ -3590,9 +3565,9 @@
       }
     },
     "globals": {
-      "version": "13.13.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
-      "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
+      "version": "13.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.15.0.tgz",
+      "integrity": "sha512-bpzcOlgDhMG070Av0Vy5Owklpv1I6+j96GhUI7Rh7IzDCKLzboflLrrfqMu8NquDbiR4EOQk7XzJwqVJxicxog==",
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
@@ -3611,12 +3586,6 @@
         "merge2": "^1.4.1",
         "slash": "^3.0.0"
       }
-    },
-    "growl": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-      "dev": true
     },
     "has-flag": {
       "version": "4.0.0",
@@ -3876,61 +3845,51 @@
       }
     },
     "mocha": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
-      "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.0.0.tgz",
+      "integrity": "sha512-0Wl+elVUD43Y0BqPZBzZt8Tnkw9CMUdNYnUsTfOM1vuhJVZL+kiesFYsqwBkEEuEixaiPe5ZQdqDgX2jddhmoA==",
       "dev": true,
       "requires": {
         "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
         "chokidar": "3.5.3",
-        "debug": "4.3.3",
+        "debug": "4.3.4",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
         "glob": "7.2.0",
-        "growl": "1.10.5",
         "he": "1.2.0",
         "js-yaml": "4.1.0",
         "log-symbols": "4.1.0",
-        "minimatch": "4.2.1",
+        "minimatch": "5.0.1",
         "ms": "2.1.3",
-        "nanoid": "3.3.1",
+        "nanoid": "3.3.3",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
-        "which": "2.0.2",
-        "workerpool": "6.2.0",
+        "workerpool": "6.2.1",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
         "yargs-unparser": "2.0.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
           "dev": true,
           "requires": {
-            "ms": "2.1.2"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-              "dev": true
-            }
+            "balanced-match": "^1.0.0"
           }
         },
         "minimatch": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
-          "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+          "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "^2.0.1"
           }
         },
         "ms": {
@@ -3951,9 +3910,9 @@
       }
     },
     "mocha-bootstrap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/mocha-bootstrap/-/mocha-bootstrap-1.0.2.tgz",
-      "integrity": "sha512-83CS/7t7lHxz4njHI4apUmGlVO4C74vSs8eX4ZUMhQLStUry/fkfS5NdGhNtnbZO73P28xHx8r4Q2Gv9b2zHlQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/mocha-bootstrap/-/mocha-bootstrap-1.0.3.tgz",
+      "integrity": "sha512-8DNjgTvN8904ZnFV9RlpB/rxeaI+sU07sm8/pTR0pJCguwUjvodQ78j5nW8aNUYKshF2OwkEeqn1MZX+58m93g==",
       "dev": true,
       "requires": {}
     },
@@ -3964,9 +3923,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
-      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
       "dev": true
     },
     "natural-compare": {
@@ -4045,11 +4004,11 @@
       }
     },
     "parsing": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/parsing/-/parsing-2.2.0.tgz",
-      "integrity": "sha512-T81oF74Ug3cdfoHMD428oxi9OALgfI+d/dpfy8ymK60dTAyQByNixEoQOtKwO0CC5t683dX4BzKWH5mUcQ4U5Q==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/parsing/-/parsing-2.3.0.tgz",
+      "integrity": "sha512-9KFnyd1tFJy1ocwgcd7aYlYo+huI1FKuxvpO48yTvjyweB6qm4oQDP9oUOaJaybY6iS9UY0tds9tTJgRmeyyPQ==",
       "requires": {
-        "microdash": "^1.4.0"
+        "microdash": "^1.4.2"
       }
     },
     "path-exists": {
@@ -4230,9 +4189,9 @@
       "dev": true
     },
     "sinon": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-13.0.2.tgz",
-      "integrity": "sha512-KvOrztAVqzSJWMDoxM4vM+GPys1df2VBoXm+YciyB/OLMamfS3VXh3oGh5WtrAGSzrgczNWFFY22oKb7Fi5eeA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-14.0.0.tgz",
+      "integrity": "sha512-ugA6BFmE+WrJdh0owRZHToLd32Uw3Lxq6E6LtNRU+xTVBefx632h03Q7apXWRsRdZAJ41LB8aUfn2+O4jsDNMw==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.8.3",
@@ -4344,9 +4303,9 @@
       }
     },
     "ts-mocha": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/ts-mocha/-/ts-mocha-9.0.2.tgz",
-      "integrity": "sha512-WyQjvnzwrrubl0JT7EC1yWmNpcsU3fOuBFfdps30zbmFBgKniSaSOyZMZx+Wq7kytUs5CY+pEbSYEbGfIKnXTw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/ts-mocha/-/ts-mocha-10.0.0.tgz",
+      "integrity": "sha512-VRfgDO+iiuJFlNB18tzOfypJ21xn2xbuZyDvJvqpTbWgkAgD17ONGr8t+Tl8rcBtOBdjXp5e/Rk+d39f7XBHRw==",
       "dev": true,
       "requires": {
         "ts-node": "7.0.1",
@@ -4410,9 +4369,9 @@
           }
         },
         "@types/node": {
-          "version": "14.18.16",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.16.tgz",
-          "integrity": "sha512-X3bUMdK/VmvrWdoTkz+VCn6nwKwrKCFTHtqwBIaQJNx4RUIBBUFXM00bqPz/DsDd+Icjmzm6/tyYZzeGVqb6/Q==",
+          "version": "14.18.18",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.18.tgz",
+          "integrity": "sha512-B9EoJFjhqcQ9OmQrNorItO+OwEOORNn3S31WuiHvZY/dm9ajkB7AKD/8toessEtHHNL+58jofbq7hMMY9v4yig==",
           "dev": true
         },
         "diff": {
@@ -4536,9 +4495,9 @@
       "dev": true
     },
     "workerpool": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
-      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
+      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
       "dev": true
     },
     "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -26,13 +26,12 @@
     "README.md"
   ],
   "scripts": {
-    "build:dev": "tsc",
-    "build:prod": "tsc -p src",
+    "build": "tsc",
     "mocha": "ts-mocha -r mocha-bootstrap --recursive 'test/integration/**/*Test.ts' 'test/unit/**/*Test.ts'",
     "lint:check": "eslint '{src,test}/**/*.ts'",
     "lint:fix": "eslint '{src,test}/**/*.ts' --fix",
-    "prepublishOnly": "npm test && npm run build:prod",
-    "test": "npm run lint:check && npm run build:dev && npm run mocha"
+    "prepublishOnly": "npm test",
+    "test": "npm run lint:check && npm run build && npm run mocha"
   },
   "dependencies": {
     "parsing": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -34,28 +34,28 @@
     "test": "npm run lint:check && npm run build && npm run mocha"
   },
   "dependencies": {
-    "parsing": "^2.2.0",
+    "parsing": "^2.3.0",
     "transpiler": "^1.2.0"
   },
   "devDependencies": {
     "@types/chai": "^4.3.1",
     "@types/mocha": "^9.1.1",
-    "@types/node": "^17.0.29",
-    "@typescript-eslint/eslint-plugin": "^5.21.0",
-    "@typescript-eslint/parser": "^5.21.0",
+    "@types/node": "^17.0.34",
+    "@typescript-eslint/eslint-plugin": "^5.25.0",
+    "@typescript-eslint/parser": "^5.25.0",
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",
-    "eslint": "^8.14.0",
+    "eslint": "^8.15.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.0.0",
-    "mocha": "^9.2.2",
-    "mocha-bootstrap": "^1.0.2",
+    "mocha": "^10.0.0",
+    "mocha-bootstrap": "^1.0.3",
     "prettier": "^2.6.2",
-    "sinon": "^13.0.2",
+    "sinon": "^14.0.0",
     "sinon-chai": "^3.7.0",
-    "ts-mocha": "^9.0.2",
+    "ts-mocha": "^10.0.0",
     "ts-sinon": "^2.0.2",
-    "typescript": "^4.6.3"
+    "typescript": "^4.6.4"
   },
   "engines": {
     "node": ">=8"

--- a/src/Emulator.ts
+++ b/src/Emulator.ts
@@ -14,6 +14,7 @@ import IntermediateToPatternCompiler from './IntermediateToPatternCompiler';
 import Matcher from './Matcher';
 import Parser, { DEFAULT_FLAGS } from './Parser';
 import PatternFactory from './PatternFactory';
+import IntermediateOptimiser from './IntermediateOptimiser';
 
 /**
  * Outermost library abstraction for PCREmu.
@@ -24,6 +25,7 @@ export default class Emulator {
         private transpiler: any,
         private parserGrammarSpec: any,
         private astToIntermediateTranspilerSpec: any,
+        private intermediateOptimiserSpecs: any[],
         private intermediateToPatternTranspilerSpec: any
     ) {}
 
@@ -57,7 +59,19 @@ export default class Emulator {
     createCompiler(): Compiler {
         return new Compiler(
             this.createAstToIntermediateCompiler(),
+            this.createIntermediateOptimiser(),
             this.createIntermediateToPatternCompiler()
+        );
+    }
+
+    /**
+     * Creates an IntermediateOptimiser.
+     */
+    createIntermediateOptimiser(): IntermediateOptimiser {
+        return new IntermediateOptimiser(
+            this.intermediateOptimiserSpecs.map((spec) =>
+                this.transpiler.create(spec)
+            )
         );
     }
 
@@ -86,5 +100,20 @@ export default class Emulator {
         );
 
         return new Parser(parsingParser);
+    }
+
+    /**
+     * Creates an IntermediateOptimiser with only the specified passes.
+     *
+     * @param {Object[]} intermediateOptimiserSpecs
+     */
+    createPartialIntermediateOptimiser(
+        intermediateOptimiserSpecs: any[]
+    ): IntermediateOptimiser {
+        return new IntermediateOptimiser(
+            intermediateOptimiserSpecs.map((spec) =>
+                this.transpiler.create(spec)
+            )
+        );
     }
 }

--- a/src/Exception/Exception.ts
+++ b/src/Exception/Exception.ts
@@ -1,0 +1,10 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+export default class Exception extends Error {}

--- a/src/IntermediateOptimiser.ts
+++ b/src/IntermediateOptimiser.ts
@@ -1,0 +1,42 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import IntermediateRepresentation from './IntermediateRepresentation';
+
+/**
+ * Optimises the Intermediate Representations (IR) of a regular expression,
+ * applying a series of passes to produce a new IR if possible.
+ */
+export default class IntermediateOptimiser {
+    constructor(private intermediatePassTranspilers: any[]) {}
+
+    /**
+     * Optimises the given IR to a new IR if possible.
+     *
+     * @param {IntermediateRepresentation} intermediateRepresentation
+     */
+    optimise(
+        intermediateRepresentation: IntermediateRepresentation
+    ): IntermediateRepresentation {
+        let optimisedTranspilerRepresentation =
+            intermediateRepresentation.getTranspilerRepresentation();
+
+        for (const passTranspiler of this.intermediatePassTranspilers) {
+            optimisedTranspilerRepresentation = passTranspiler.transpile(
+                optimisedTranspilerRepresentation
+            );
+        }
+
+        return new IntermediateRepresentation(
+            optimisedTranspilerRepresentation,
+            intermediateRepresentation.getPattern(),
+            intermediateRepresentation.getFlags()
+        );
+    }
+}

--- a/src/IntermediateToPatternCompiler.ts
+++ b/src/IntermediateToPatternCompiler.ts
@@ -81,6 +81,10 @@ export default class IntermediateToPatternCompiler {
             nativeFlags += 'i';
         }
 
+        if (flags.dotAll) {
+            nativeFlags += 's';
+        }
+
         if (flags.multiline) {
             nativeFlags += 'm';
         }

--- a/src/IntermediateToPatternCompiler.ts
+++ b/src/IntermediateToPatternCompiler.ts
@@ -7,10 +7,10 @@
  * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
  */
 
-import { Context } from './spec/intermediateToPattern';
 import IntermediateRepresentation from './IntermediateRepresentation';
 import Pattern from './Pattern';
 import PatternFactory from './PatternFactory';
+import PatternFragment from './Match/Fragment/PatternFragment';
 
 /**
  * Compiles the Intermediate Representation (IR) of a regular expression to a Pattern instance.
@@ -27,74 +27,13 @@ export default class IntermediateToPatternCompiler {
      * @param {IntermediateRepresentation} intermediateRepresentation
      */
     compile(intermediateRepresentation: IntermediateRepresentation): Pattern {
-        // Note we include "0" as the entire match is always captured as group 0.
-        const capturingGroupNames: Array<number | string> = [0];
-        let patternCapturingGroupCount = 1;
-        const patternToEmulatedNumberedGroupIndex: number[] = [0];
-        let emulatedCapturingGroupCount = 1;
-
-        const context: Context = {
-            /**
-             * @inheritDoc
-             */
-            addAtomicGroup(): number {
-                return emulatedCapturingGroupCount++;
-            },
-
-            /**
-             * @inheritDoc
-             */
-            addNamedCapturingGroup(name: number | string) {
-                capturingGroupNames.push(name);
-                // Named capturing groups are also stored by their index.
-                capturingGroupNames.push(patternCapturingGroupCount++);
-
-                patternToEmulatedNumberedGroupIndex.push(
-                    emulatedCapturingGroupCount++
-                );
-            },
-
-            /**
-             * @inheritDoc
-             */
-            addNumberedCapturingGroup() {
-                capturingGroupNames.push(patternCapturingGroupCount++);
-
-                patternToEmulatedNumberedGroupIndex.push(
-                    emulatedCapturingGroupCount++
-                );
-            },
-        };
-        const regexPattern = this.intermediateToPatternTranspiler.transpile(
+        const flags = intermediateRepresentation.getFlags();
+        const context = { flags };
+        const patternFragment = this.intermediateToPatternTranspiler.transpile(
             intermediateRepresentation.getTranspilerRepresentation(),
             context
-        );
-        const flags = intermediateRepresentation.getFlags();
-        // Always include the "d" flag for capture indices/offsets and "g" to allow offset to be specified.
-        let nativeFlags = 'dg';
+        ) as PatternFragment;
 
-        if (flags.anchored) {
-            nativeFlags += 'y'; // Use ES6 "sticky" modifier "y".
-        }
-
-        if (flags.caseless) {
-            nativeFlags += 'i';
-        }
-
-        if (flags.dotAll) {
-            nativeFlags += 's';
-        }
-
-        if (flags.multiline) {
-            nativeFlags += 'm';
-        }
-
-        const regex = new RegExp(regexPattern, nativeFlags);
-
-        return this.patternFactory.createPattern(
-            regex,
-            capturingGroupNames,
-            patternToEmulatedNumberedGroupIndex
-        );
+        return this.patternFactory.createPattern(patternFragment, flags);
     }
 }

--- a/src/Match/Fragment/AlternationFragment.ts
+++ b/src/Match/Fragment/AlternationFragment.ts
@@ -1,0 +1,94 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import AlternativeFragment from './AlternativeFragment';
+import FragmentInterface from './FragmentInterface';
+import FragmentMatch from '../FragmentMatch';
+
+/**
+ * Matches one of a series of possible alternatives.
+ *
+ * Comprised of {@see {AlternativeFragment}} components.
+ */
+export default class AlternationFragment implements FragmentInterface {
+    constructor(private alternativeFragments: AlternativeFragment[]) {}
+
+    /**
+     * @inheritDoc
+     */
+    match(
+        subject: string,
+        position: number,
+        isAnchored: boolean
+    ): FragmentMatch | null {
+        let alternativeIndex = 0;
+
+        const tryNextAlternative = (): FragmentMatch | null => {
+            for (
+                ;
+                alternativeIndex < this.alternativeFragments.length;
+                alternativeIndex++
+            ) {
+                const alternativeFragment =
+                    this.alternativeFragments[alternativeIndex];
+
+                const match = alternativeFragment.match(
+                    subject,
+                    position,
+                    isAnchored
+                );
+
+                if (match) {
+                    // Match succeeded.
+                    return match.wrapBacktracker(
+                        (previousMatch, previousBacktracker) => {
+                            const backtrackedMatch = previousBacktracker();
+
+                            if (backtrackedMatch) {
+                                // The inside of the alternative was able to be backtracked, so we'll use that for now.
+                                return backtrackedMatch;
+                            }
+
+                            // Otherwise, we could not backtrack inside the alternative itself,
+                            // so we'll need to try the next alternative instead.
+                            alternativeIndex++;
+
+                            return tryNextAlternative();
+                        }
+                    );
+                }
+            }
+
+            return null; // None of the alternatives matched.
+        };
+
+        return tryNextAlternative();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    toString(): string {
+        return this.alternativeFragments
+            .map((alternativeFragment) => alternativeFragment.toString())
+            .join('|');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    toStructure(): object {
+        return {
+            type: 'alternation',
+            alternatives: this.alternativeFragments.map((alternativeFragment) =>
+                alternativeFragment.toStructure()
+            ),
+        };
+    }
+}

--- a/src/Match/Fragment/AlternativeFragment.ts
+++ b/src/Match/Fragment/AlternativeFragment.ts
@@ -1,0 +1,61 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import FragmentInterface from './FragmentInterface';
+import FragmentMatcher from '../FragmentMatcher';
+import FragmentMatch from '../FragmentMatch';
+
+/**
+ * Forms part of an alternation.
+ *
+ * @see {AlternationFragment}
+ */
+export default class AlternativeFragment implements FragmentInterface {
+    constructor(
+        private fragmentMatcher: FragmentMatcher,
+        private componentFragments: FragmentInterface[]
+    ) {}
+
+    /**
+     * @inheritDoc
+     */
+    match(
+        subject: string,
+        position: number,
+        isAnchored: boolean
+    ): FragmentMatch | null {
+        return this.fragmentMatcher.matchComponents(
+            subject,
+            position,
+            isAnchored,
+            this.componentFragments
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    toString(): string {
+        return this.componentFragments
+            .map((componentFragment) => componentFragment.toString())
+            .join('');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    toStructure(): object {
+        return {
+            type: 'alternative',
+            components: this.componentFragments.map((componentFragment) =>
+                componentFragment.toStructure()
+            ),
+        };
+    }
+}

--- a/src/Match/Fragment/CapturingGroupFragment.ts
+++ b/src/Match/Fragment/CapturingGroupFragment.ts
@@ -1,0 +1,71 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import FragmentInterface from './FragmentInterface';
+import FragmentMatch from '../FragmentMatch';
+import FragmentMatcher from '../FragmentMatcher';
+
+/**
+ * Captures part of a regular expression match as a given numbered index.
+ */
+export default class CapturingGroupFragment implements FragmentInterface {
+    constructor(
+        private fragmentMatcher: FragmentMatcher,
+        private componentFragments: FragmentInterface[],
+        private groupIndex: number
+    ) {}
+
+    /**
+     * @inheritDoc
+     */
+    match(
+        subject: string,
+        position: number,
+        isAnchored: boolean
+    ): FragmentMatch | null {
+        const match = this.fragmentMatcher.matchComponents(
+            subject,
+            position,
+            isAnchored,
+            this.componentFragments
+        );
+
+        if (!match) {
+            return null;
+        }
+
+        return match.withCaptureAs(this.groupIndex);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    toString(): string {
+        return (
+            '(' +
+            this.componentFragments
+                .map((componentFragment) => componentFragment.toString())
+                .join('|') +
+            ')'
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    toStructure(): object {
+        return {
+            type: 'capturing-group',
+            groupIndex: this.groupIndex,
+            components: this.componentFragments.map((componentFragment) =>
+                componentFragment.toStructure()
+            ),
+        };
+    }
+}

--- a/src/Match/Fragment/CapturingGroupFragment.ts
+++ b/src/Match/Fragment/CapturingGroupFragment.ts
@@ -51,7 +51,7 @@ export default class CapturingGroupFragment implements FragmentInterface {
             '(' +
             this.componentFragments
                 .map((componentFragment) => componentFragment.toString())
-                .join('|') +
+                .join('') +
             ')'
         );
     }

--- a/src/Match/Fragment/FragmentInterface.ts
+++ b/src/Match/Fragment/FragmentInterface.ts
@@ -1,0 +1,35 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import FragmentMatch from '../FragmentMatch';
+
+export default interface FragmentInterface {
+    /**
+     * Attempts to match this fragment against the given subject string.
+     *
+     * @param {string} subject
+     * @param {number} position
+     * @param {boolean} isAnchored
+     */
+    match(
+        subject: string,
+        position: number,
+        isAnchored: boolean
+    ): FragmentMatch | null;
+
+    /**
+     * Fetches a string representation of this pattern fragment.
+     */
+    toString(): string;
+
+    /**
+     * Fetches a recursive structure representing the pattern's fragments.
+     */
+    toStructure(): object;
+}

--- a/src/Match/Fragment/LiteralFragment.ts
+++ b/src/Match/Fragment/LiteralFragment.ts
@@ -1,0 +1,59 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import FragmentInterface from './FragmentInterface';
+import FragmentMatch from '../FragmentMatch';
+
+/**
+ * Matches a series of plain characters with no special meaning.
+ */
+export default class LiteralFragment implements FragmentInterface {
+    constructor(private chars: string) {}
+
+    /**
+     * @inheritDoc
+     */
+    match(
+        subject: string,
+        position: number,
+        isAnchored: boolean
+    ): FragmentMatch | null {
+        const matchPosition = subject.indexOf(this.chars, position);
+
+        if (matchPosition === -1) {
+            // Literal is not present in the subject string at any point past the start position.
+            return null;
+        }
+
+        if (isAnchored && matchPosition > position) {
+            // Anchored matches must be at the start position.
+            return null;
+        }
+
+        // Note no backtracking is possible.
+        return new FragmentMatch(matchPosition, this.chars);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    toString(): string {
+        return this.chars;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    toStructure(): object {
+        return {
+            type: 'literal',
+            chars: this.chars,
+        };
+    }
+}

--- a/src/Match/Fragment/MaximisingQuantifierFragment.ts
+++ b/src/Match/Fragment/MaximisingQuantifierFragment.ts
@@ -1,0 +1,104 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import FragmentInterface from './FragmentInterface';
+import FragmentMatch from '../FragmentMatch';
+import FragmentMatcher from '../FragmentMatcher';
+import QuantifierMatcher from '../QuantifierMatcher';
+
+/**
+ * Matches greedily, giving up matches if/as required during backtracking.
+ */
+export default class MaximisingQuantifierFragment implements FragmentInterface {
+    constructor(
+        private fragmentMatcher: FragmentMatcher,
+        private quantifierMatcher: QuantifierMatcher,
+        private componentFragment: FragmentInterface,
+        private minimumMatches: number,
+        private maximumMatches: number | null
+    ) {}
+
+    /**
+     * @inheritDoc
+     */
+    match(
+        subject: string,
+        position: number,
+        isAnchored: boolean
+    ): FragmentMatch | null {
+        const initialPosition = position;
+
+        const backtracker = (
+            matches: FragmentMatch[]
+        ): FragmentMatch | null => {
+            let backtrackedMatch = matches[matches.length - 1].backtrack();
+
+            if (backtrackedMatch) {
+                // Overwrite the latest match with its backtracked version.
+                matches[matches.length - 1] = backtrackedMatch;
+            } else {
+                // Otherwise, we could not backtrack this repeated instance of the match,
+                // so we'll need to give up the whole instance (assuming we still meet our minimum).
+                matches.pop(); // Give up the latest match.
+
+                if (matches.length === 0) {
+                    // We've given up the final instance, therefore the whole match for this quantifier has failed.
+                    return null;
+                }
+
+                if (matches.length < this.minimumMatches) {
+                    return null; // Minimum would no longer be met, so this entire repeated match fails.
+                }
+
+                // Use the previous repetition as the new backtracked match.
+                backtrackedMatch = matches[matches.length - 1];
+            }
+
+            position = backtrackedMatch.getEnd();
+
+            return this.fragmentMatcher.concatenateMatches(
+                matches,
+                initialPosition,
+                () => backtracker(matches)
+            );
+        };
+
+        return this.quantifierMatcher.matchMaximising(
+            subject,
+            position,
+            isAnchored,
+            this.componentFragment,
+            this.minimumMatches,
+            this.maximumMatches,
+            backtracker
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    toString(): string {
+        return (
+            this.componentFragment.toString() +
+            `{${this.minimumMatches},${this.maximumMatches ?? ''}}`
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    toStructure(): object {
+        return {
+            type: 'maximising-quantifier',
+            minimumMatches: this.minimumMatches,
+            maximumMatches: this.maximumMatches,
+            component: this.componentFragment.toStructure(),
+        };
+    }
+}

--- a/src/Match/Fragment/MaximisingQuantifierFragment.ts
+++ b/src/Match/Fragment/MaximisingQuantifierFragment.ts
@@ -37,9 +37,9 @@ export default class MaximisingQuantifierFragment implements FragmentInterface {
         const backtracker = (
             matches: FragmentMatch[]
         ): FragmentMatch | null => {
-            if (matches.length === this.minimumMatches) {
-                // We've already got a minimal match of this quantifier,
-                // we cannot backtrack further.
+            if (matches.length === 0) {
+                // We've got an empty match (therefore minimum must be zero)
+                // so we cannot backtrack.
                 return null;
             }
 
@@ -49,6 +49,12 @@ export default class MaximisingQuantifierFragment implements FragmentInterface {
                 // Overwrite the latest match with its backtracked version.
                 matches[matches.length - 1] = backtrackedMatch;
             } else {
+                if (matches.length === this.minimumMatches) {
+                    // We've already got a minimal match of this quantifier,
+                    // we cannot give up any matches.
+                    return null;
+                }
+
                 // Otherwise, we could not backtrack this repeated instance of the match,
                 // so we'll need to give up the whole instance (assuming we still meet our minimum).
                 matches.pop(); // Give up the latest match.

--- a/src/Match/Fragment/MaximisingQuantifierFragment.ts
+++ b/src/Match/Fragment/MaximisingQuantifierFragment.ts
@@ -37,6 +37,12 @@ export default class MaximisingQuantifierFragment implements FragmentInterface {
         const backtracker = (
             matches: FragmentMatch[]
         ): FragmentMatch | null => {
+            if (matches.length === this.minimumMatches) {
+                // We've already got a minimal match of this quantifier,
+                // we cannot backtrack further.
+                return null;
+            }
+
             let backtrackedMatch = matches[matches.length - 1].backtrack();
 
             if (backtrackedMatch) {

--- a/src/Match/Fragment/MinimisingQuantifierFragment.ts
+++ b/src/Match/Fragment/MinimisingQuantifierFragment.ts
@@ -1,0 +1,135 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import FragmentInterface from './FragmentInterface';
+import FragmentMatch from '../FragmentMatch';
+import FragmentMatcher from '../FragmentMatcher';
+
+/**
+ * Performs a lazy match with the given quantifier.
+ */
+export default class MinimisingQuantifierFragment implements FragmentInterface {
+    constructor(
+        private fragmentMatcher: FragmentMatcher,
+        private componentFragment: FragmentInterface,
+        private minimumMatches: number,
+        private maximumMatches: number | null
+    ) {}
+
+    /**
+     * @inheritDoc
+     */
+    match(
+        subject: string,
+        position: number,
+        isAnchored: boolean
+    ): FragmentMatch | null {
+        const initialPosition = position;
+        const matches: FragmentMatch[] = [];
+
+        for (
+            let matchIndex = 0;
+            matchIndex < this.minimumMatches;
+            matchIndex++
+        ) {
+            const match = this.componentFragment.match(
+                subject,
+                position,
+                isAnchored
+            );
+
+            if (!match) {
+                // One of the minimum required matches has failed,
+                // so the entire quantifier match has failed.
+                return null;
+            }
+
+            matches.push(match);
+
+            position = match.getEnd();
+        }
+
+        let backtrackingBackwards = true;
+
+        const backtracker = (): FragmentMatch | null => {
+            if (backtrackingBackwards && matches.length > 0) {
+                const previousMatch = matches[matches.length - 1];
+                const backtrackedMatch = previousMatch.backtrack();
+
+                if (backtrackedMatch) {
+                    position = backtrackedMatch.getEnd();
+
+                    // Replace with the backtracked match in our record.
+                    matches[matches.length - 1] = backtrackedMatch;
+
+                    return this.fragmentMatcher.concatenateMatches(
+                        matches,
+                        initialPosition,
+                        backtracker
+                    );
+                }
+            }
+
+            backtrackingBackwards = false;
+
+            // FIXME: Check max
+
+            const nextMatch = this.componentFragment.match(
+                subject,
+                position,
+                isAnchored
+            );
+
+            if (!nextMatch) {
+                // Tracking forwards has also failed,
+                // so the entire quantifier match has failed.
+                return null;
+            }
+
+            position = nextMatch.getEnd();
+
+            // Add the new match to our record.
+            matches.push(nextMatch);
+
+            return this.fragmentMatcher.concatenateMatches(
+                matches,
+                initialPosition,
+                backtracker
+            );
+        };
+
+        return this.fragmentMatcher.concatenateMatches(
+            matches,
+            initialPosition,
+            backtracker
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    toString(): string {
+        return (
+            this.componentFragment.toString() +
+            `{${this.minimumMatches},${this.maximumMatches ?? ''}}?`
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    toStructure(): object {
+        return {
+            type: 'minimising-quantifier',
+            minimumMatches: this.minimumMatches,
+            maximumMatches: this.maximumMatches,
+            component: this.componentFragment.toStructure(),
+        };
+    }
+}

--- a/src/Match/Fragment/NamedCapturingGroupFragment.ts
+++ b/src/Match/Fragment/NamedCapturingGroupFragment.ts
@@ -50,7 +50,7 @@ export default class NamedCapturingGroupFragment implements FragmentInterface {
     toString(): string {
         const inner = this.componentFragments
             .map((componentFragment) => componentFragment.toString())
-            .join('|');
+            .join('');
 
         return `(?<${this.groupName}>${inner})`;
     }

--- a/src/Match/Fragment/NamedCapturingGroupFragment.ts
+++ b/src/Match/Fragment/NamedCapturingGroupFragment.ts
@@ -1,0 +1,71 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import FragmentInterface from './FragmentInterface';
+import FragmentMatch from '../FragmentMatch';
+import FragmentMatcher from '../FragmentMatcher';
+
+/**
+ * Captures part of a regular expression match as both a given numbered index and name.
+ */
+export default class NamedCapturingGroupFragment implements FragmentInterface {
+    constructor(
+        private fragmentMatcher: FragmentMatcher,
+        private componentFragments: FragmentInterface[],
+        private groupIndex: number,
+        private groupName: string
+    ) {}
+
+    /**
+     * @inheritDoc
+     */
+    match(
+        subject: string,
+        position: number,
+        isAnchored: boolean
+    ): FragmentMatch | null {
+        const match = this.fragmentMatcher.matchComponents(
+            subject,
+            position,
+            isAnchored,
+            this.componentFragments
+        );
+
+        if (!match) {
+            return null;
+        }
+
+        return match.withCaptureAs(this.groupIndex, this.groupName);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    toString(): string {
+        const inner = this.componentFragments
+            .map((componentFragment) => componentFragment.toString())
+            .join('|');
+
+        return `(?<${this.groupName}>${inner})`;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    toStructure(): object {
+        return {
+            type: 'named-capturing-group',
+            groupIndex: this.groupIndex,
+            groupName: this.groupName,
+            components: this.componentFragments.map((componentFragment) =>
+                componentFragment.toStructure()
+            ),
+        };
+    }
+}

--- a/src/Match/Fragment/NativeFragment.ts
+++ b/src/Match/Fragment/NativeFragment.ts
@@ -1,0 +1,206 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import FragmentInterface from './FragmentInterface';
+import FragmentMatch from '../FragmentMatch';
+import {
+    Flags,
+    IndexCapturingRegExpExecArray,
+    RegExpMatchArrayIndices,
+} from '../../declarations/types';
+
+/**
+ * Matches the subject string against a fragment of native JavaScript regex.
+ */
+export default class NativeFragment implements FragmentInterface {
+    constructor(
+        private chars: string,
+        private patternToEmulatedNumberedGroupIndex: {
+            [key: number]: number;
+        },
+        private flags: Flags
+    ) {}
+
+    /**
+     * @inheritDoc
+     */
+    match(
+        subject: string,
+        position: number,
+        isAnchored: boolean
+    ): FragmentMatch | null {
+        // Always include the "d" flag for capture indices/offsets and "g" to allow offset to be specified.
+        let nativeFlags = 'dg';
+
+        if (isAnchored) {
+            nativeFlags += 'y';
+        }
+
+        if (this.flags.caseless) {
+            nativeFlags += 'i';
+        }
+
+        if (this.flags.multiline) {
+            nativeFlags += 'm'; // FIXME: See note below re. multiline and "$".
+        }
+
+        if (this.flags.dotAll) {
+            nativeFlags += 's';
+        }
+
+        const normalNativeRegex = new RegExp(this.chars, nativeFlags);
+
+        // Ensure we never use native multiline mode, as $ must always match end-of-string only
+        // in order for backtracking logic to work.
+        // FIXME: Use a lookahead instead or in conjunction with "$" to allow native multiline
+        //        mode to be used while still supporting end-of-string here.
+        const backtrackingRegex = new RegExp(this.chars + '$', nativeFlags);
+
+        const match = (
+            regex: RegExp,
+            subjectSlice: string
+        ): FragmentMatch | null => {
+            // Note we always use the "g" flag to ensure matches can only start at or after the given start offset.
+            regex.lastIndex = position;
+
+            const match = regex.exec(
+                subjectSlice
+            ) as IndexCapturingRegExpExecArray | null;
+
+            if (!match) {
+                return null;
+            }
+
+            const numberedCaptures: string[] = [];
+            const numberedCaptureIndices: RegExpMatchArrayIndices =
+                [] as unknown as RegExpMatchArrayIndices;
+
+            // Map the numbered match captures from the emulated groups in the native regex to the original pattern.
+            for (const patternIndexKey of Object.keys(
+                this.patternToEmulatedNumberedGroupIndex
+            )) {
+                const patternIndex = Number(patternIndexKey);
+                const emulatedIndex =
+                    this.patternToEmulatedNumberedGroupIndex[patternIndex];
+
+                numberedCaptures[patternIndex] = match[emulatedIndex];
+                numberedCaptureIndices[patternIndex] =
+                    match.indices[emulatedIndex];
+            }
+
+            const namedCaptures = match.groups || {};
+            const namedCaptureIndices = match.indices.groups;
+
+            const capture = match[0];
+
+            return new FragmentMatch(
+                regex.lastIndex - capture.length, // Re-read .lastIndex to get the actual position.
+                capture,
+                numberedCaptures,
+                namedCaptures,
+                numberedCaptureIndices,
+                namedCaptureIndices,
+                backtrack
+            );
+        };
+
+        /**
+         * Backtracking logic:
+         *
+         * - Append an end-of-string anchor "$" to the native regex.
+         * - Attempt to match subject string[0...matchEnd+1].
+         * - If this fails, the match was maximising so backtracking needs to go backwards
+         *   (towards the start of the subject string).
+         * - If this succeeds, the match was minimising so backtracking needs to go forwards
+         *   (towards the end of the subject string).
+         *
+         * Backtracking is performed by slicing the subject up for the current backtrack position.
+         */
+
+        const initialBacktrack = (
+            previousMatch: FragmentMatch
+        ): FragmentMatch | null => {
+            const backtrackMatch = forwardBacktrack(previousMatch);
+
+            if (backtrackMatch) {
+                // Match was minimising - backtracking needs to go forwards.
+                currentBacktrack = forwardBacktrack;
+
+                // Note there is no need to call forwardBacktrack() this time - we've already performed one.
+                return backtrackMatch;
+            }
+
+            // Match was maximising - backtracking needs to go backwards instead.
+            currentBacktrack = backwardBacktrack;
+
+            return backwardBacktrack(previousMatch);
+        };
+
+        const forwardBacktrack = (
+            previousMatch: FragmentMatch
+        ): FragmentMatch | null => {
+            if (previousMatch.getEnd() === subject.length) {
+                // Match is already at end of string: there are no more characters to go.
+                return null;
+            }
+
+            const subjectSlice = subject.substring(
+                0,
+                previousMatch.getLength() + 1
+            );
+
+            return match(backtrackingRegex, subjectSlice);
+        };
+
+        const backwardBacktrack = (
+            previousMatch: FragmentMatch
+        ): FragmentMatch | null => {
+            if (previousMatch.getEnd() === position) {
+                // Match is already back at start: there are no more characters to go.
+                return null;
+            }
+
+            const subjectSlice = subject.substring(
+                0,
+                previousMatch.getLength() - 1
+            );
+
+            return match(backtrackingRegex, subjectSlice);
+        };
+
+        let currentBacktrack = initialBacktrack;
+
+        const backtrack = (
+            previousMatch: FragmentMatch
+        ): FragmentMatch | null => {
+            return currentBacktrack(previousMatch);
+        };
+
+        return match(normalNativeRegex, subject);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    toString(): string {
+        return this.chars;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    toStructure(): object {
+        return {
+            type: 'native',
+            chars: this.chars,
+            patternToEmulatedNumberedGroupIndex:
+                this.patternToEmulatedNumberedGroupIndex,
+        };
+    }
+}

--- a/src/Match/Fragment/NonCapturingGroupFragment.ts
+++ b/src/Match/Fragment/NonCapturingGroupFragment.ts
@@ -1,0 +1,61 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import FragmentInterface from './FragmentInterface';
+import FragmentMatch from '../FragmentMatch';
+import FragmentMatcher from '../FragmentMatcher';
+
+/**
+ * Groups part of a regular expression, without causing the result to be captured.
+ */
+export default class NonCapturingGroupFragment implements FragmentInterface {
+    constructor(
+        private fragmentMatcher: FragmentMatcher,
+        private componentFragments: FragmentInterface[]
+    ) {}
+
+    /**
+     * @inheritDoc
+     */
+    match(
+        subject: string,
+        position: number,
+        isAnchored: boolean
+    ): FragmentMatch | null {
+        return this.fragmentMatcher.matchComponents(
+            subject,
+            position,
+            isAnchored,
+            this.componentFragments
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    toString(): string {
+        const inner = this.componentFragments
+            .map((componentFragment) => componentFragment.toString())
+            .join('|');
+
+        return `(?:${inner})`;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    toStructure(): object {
+        return {
+            type: 'non-capturing-group',
+            components: this.componentFragments.map((componentFragment) =>
+                componentFragment.toStructure()
+            ),
+        };
+    }
+}

--- a/src/Match/Fragment/NonCapturingGroupFragment.ts
+++ b/src/Match/Fragment/NonCapturingGroupFragment.ts
@@ -42,7 +42,7 @@ export default class NonCapturingGroupFragment implements FragmentInterface {
     toString(): string {
         const inner = this.componentFragments
             .map((componentFragment) => componentFragment.toString())
-            .join('|');
+            .join('');
 
         return `(?:${inner})`;
     }

--- a/src/Match/Fragment/NoopFragment.ts
+++ b/src/Match/Fragment/NoopFragment.ts
@@ -1,0 +1,39 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import FragmentInterface from './FragmentInterface';
+import FragmentMatch from '../FragmentMatch';
+
+/**
+ * Represents a part of a matcher pattern that does nothing; may be the result of an optimisation.
+ */
+export default class NoopFragment implements FragmentInterface {
+    /**
+     * @inheritDoc
+     */
+    match(subject: string, position: number): FragmentMatch | null {
+        return new FragmentMatch(position);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    toString(): string {
+        return '';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    toStructure(): object {
+        return {
+            type: 'noop',
+        };
+    }
+}

--- a/src/Match/Fragment/PatternFragment.ts
+++ b/src/Match/Fragment/PatternFragment.ts
@@ -1,0 +1,79 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import FragmentInterface from './FragmentInterface';
+import FragmentMatch from '../FragmentMatch';
+import FragmentMatcher from '../FragmentMatcher';
+
+/**
+ * Matches the given subject string.
+ *
+ * Top level of the Fragment tree.
+ */
+export default class PatternFragment implements FragmentInterface {
+    constructor(
+        private fragmentMatcher: FragmentMatcher,
+        private componentFragments: FragmentInterface[],
+        private capturingGroupNames: Array<number | string>
+    ) {}
+
+    /**
+     * Fetches all numbered and named capturing group names for the pattern,
+     * in the order they are defined.
+     *
+     * Note that named capturing groups also appear by their index.
+     */
+    getCapturingGroupNames(): Array<number | string> {
+        return this.capturingGroupNames;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    match(
+        subject: string,
+        position: number,
+        isAnchored: boolean
+    ): FragmentMatch | null {
+        const match = this.fragmentMatcher.matchComponents(
+            subject,
+            position,
+            isAnchored,
+            this.componentFragments
+        );
+
+        if (!match) {
+            return null;
+        }
+
+        return match.withMissingCapturesBackfilled(this.capturingGroupNames);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    toString(): string {
+        return this.componentFragments
+            .map((componentFragment) => componentFragment.toString())
+            .join('');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    toStructure(): object {
+        return {
+            type: 'pattern',
+            capturingGroups: this.capturingGroupNames,
+            components: this.componentFragments.map((componentFragment) =>
+                componentFragment.toStructure()
+            ),
+        };
+    }
+}

--- a/src/Match/Fragment/PatternFragment.ts
+++ b/src/Match/Fragment/PatternFragment.ts
@@ -41,18 +41,26 @@ export default class PatternFragment implements FragmentInterface {
         position: number,
         isAnchored: boolean
     ): FragmentMatch | null {
-        const match = this.fragmentMatcher.matchComponents(
-            subject,
-            position,
-            isAnchored,
-            this.componentFragments
-        );
+        do {
+            const match = this.fragmentMatcher.matchComponents(
+                subject,
+                position,
+                isAnchored,
+                this.componentFragments
+            );
 
-        if (!match) {
-            return null;
-        }
+            if (match) {
+                return match.withMissingCapturesBackfilled(
+                    this.capturingGroupNames
+                );
+            }
 
-        return match.withMissingCapturesBackfilled(this.capturingGroupNames);
+            // Match failed: if it is un-anchored then the top-level of the pattern is special,
+            // as it can then move to the next character position to try again.
+            position++;
+        } while (!isAnchored && position < subject.length);
+
+        return null;
     }
 
     /**

--- a/src/Match/Fragment/PossessiveQuantifierFragment.ts
+++ b/src/Match/Fragment/PossessiveQuantifierFragment.ts
@@ -1,0 +1,67 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import FragmentInterface from './FragmentInterface';
+import FragmentMatch from '../FragmentMatch';
+import QuantifierMatcher from '../QuantifierMatcher';
+
+/**
+ * Matches greedily similar to a maximising match,
+ * however no part of the match will ever be given up, i.e. backtracking is prevented.
+ */
+export default class PossessiveQuantifierFragment implements FragmentInterface {
+    constructor(
+        private quantifierMatcher: QuantifierMatcher,
+        private componentFragment: FragmentInterface,
+        private minimumMatches: number,
+        private maximumMatches: number | null
+    ) {}
+
+    /**
+     * @inheritDoc
+     */
+    match(
+        subject: string,
+        position: number,
+        isAnchored: boolean
+    ): FragmentMatch | null {
+        return this.quantifierMatcher.matchMaximising(
+            subject,
+            position,
+            isAnchored,
+            this.componentFragment,
+            this.minimumMatches,
+            this.maximumMatches,
+            // Possessive matches cannot backtrack.
+            () => null
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    toString(): string {
+        return (
+            this.componentFragment.toString() +
+            `{${this.minimumMatches},${this.maximumMatches ?? ''}}+`
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    toStructure(): object {
+        return {
+            type: 'possessive-quantifier',
+            minimumMatches: this.minimumMatches,
+            maximumMatches: this.maximumMatches,
+            component: this.componentFragment.toStructure(),
+        };
+    }
+}

--- a/src/Match/FragmentMatch.ts
+++ b/src/Match/FragmentMatch.ts
@@ -1,0 +1,199 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import {
+    Backtracker,
+    NamedCaptureIndices,
+    NamedCaptures,
+    NumberedCaptureIndices,
+    NumberedCaptures,
+} from '../spec/types/match';
+
+const hasOwn = {}.hasOwnProperty;
+
+/**
+ * Represents a match against a subject string.
+ *
+ * This is an internal representation used during matching;
+ * once the final result is known it will be returned as a Match instead.
+ */
+export default class FragmentMatch {
+    constructor(
+        private position: number,
+        private capture: string = '',
+        private numberedCaptures: NumberedCaptures = {},
+        private namedCaptures: NamedCaptures = {},
+        private numberedCaptureIndices: NumberedCaptureIndices = {},
+        private namedCaptureIndices: NamedCaptureIndices = {},
+        // Default backtracker will always return null (ie. will always fail).
+        private backtracker: Backtracker = () => null
+    ) {}
+
+    /**
+     * Attempts to backtrack from this fragment match one position.
+     */
+    backtrack(): FragmentMatch | null {
+        return this.backtracker(this);
+    }
+
+    /**
+     * Fetches the entire match.
+     */
+    getCapture(): string {
+        // Note that we cannot fetch the capture with index 0 as it is not defined for FragmentMatches.
+        return this.capture;
+    }
+
+    /**
+     * Fetches the zero-based offset of the end of this match into the subject string.
+     */
+    getEnd(): number {
+        return this.position + this.capture.length;
+    }
+
+    /**
+     * Fetches the total length of this match.
+     */
+    getLength(): number {
+        return this.capture.length;
+    }
+
+    /**
+     * Fetches a map from named capture name to indices.
+     */
+    getNamedCaptureIndices(): NamedCaptureIndices {
+        return Object.assign({}, this.namedCaptureIndices);
+    }
+
+    /**
+     * Fetches a map from named capture name to captured text.
+     */
+    getNamedCaptures(): NamedCaptures {
+        return Object.assign({}, this.namedCaptures);
+    }
+
+    /**
+     * Fetches a map from numbered capture name to indices.
+     */
+    getNumberedCaptureIndices(): NumberedCaptureIndices {
+        return Object.assign({}, this.numberedCaptureIndices);
+    }
+
+    /**
+     * Fetches a map from numbered capture name to captured text.
+     */
+    getNumberedCaptures(): NumberedCaptures {
+        return Object.assign({}, this.numberedCaptures);
+    }
+
+    /**
+     * Fetches the zero-based offset of the start of this match into the subject string.
+     */
+    getStart(): number {
+        return this.position;
+    }
+
+    /**
+     * Creates a new FragmentMatch with the entire capture stored under the given index,
+     * optionally by name too.
+     *
+     * @param {number} index
+     * @param {string=} name
+     */
+    withCaptureAs(index: number, name?: string): FragmentMatch {
+        const numberedCaptures = this.getNumberedCaptures();
+        const namedCaptures = this.getNamedCaptures();
+        const numberedCaptureIndices = this.getNumberedCaptureIndices();
+        const namedCaptureIndices = this.getNamedCaptureIndices();
+
+        // Add the full match as the specified capturing group. Note this may not be 0 for emulated capturing groups.
+        numberedCaptures[index] = this.getCapture();
+        numberedCaptureIndices[index] = [this.getStart(), this.getEnd()];
+
+        if (name !== undefined) {
+            // As above, but for a named capturing group.
+            namedCaptures[name] = this.getCapture();
+            namedCaptureIndices[name] = [this.getStart(), this.getEnd()];
+        }
+
+        return new FragmentMatch(
+            this.position,
+            this.capture,
+            numberedCaptures,
+            namedCaptures,
+            numberedCaptureIndices,
+            namedCaptureIndices,
+            this.backtracker
+        );
+    }
+
+    /**
+     * Creates a new FragmentMatch with any of the specified captures backfilled
+     * with empty matches if they are missing.
+     *
+     * @param {Array<number, string>} capturingGroupNames
+     */
+    withMissingCapturesBackfilled(
+        capturingGroupNames: (number | string)[]
+    ): FragmentMatch {
+        const numberedCaptures = this.getNumberedCaptures();
+        const namedCaptures = this.getNamedCaptures();
+        const numberedCaptureIndices = this.getNumberedCaptureIndices();
+        const namedCaptureIndices = this.getNamedCaptureIndices();
+
+        for (const name of capturingGroupNames) {
+            if (typeof name === 'number') {
+                const index = name;
+
+                if (!hasOwn.call(numberedCaptures, index)) {
+                    numberedCaptures[index] = null;
+                    numberedCaptureIndices[index] = [-1, -1];
+                }
+            } else {
+                // As above, but for a named capturing group.
+                if (!hasOwn.call(namedCaptures, name)) {
+                    namedCaptures[name] = null;
+                    namedCaptureIndices[name] = [-1, -1];
+                }
+            }
+        }
+
+        return new FragmentMatch(
+            this.position,
+            this.capture,
+            numberedCaptures,
+            namedCaptures,
+            numberedCaptureIndices,
+            namedCaptureIndices,
+            this.backtracker
+        );
+    }
+
+    /**
+     * Creates a new FragmentMatch with the given backtracker.
+     *
+     * @param {Function} backtracker
+     */
+    wrapBacktracker(
+        backtracker: (
+            previousMatch: FragmentMatch,
+            previousBacktracker: () => FragmentMatch | null
+        ) => FragmentMatch | null
+    ): FragmentMatch {
+        return new FragmentMatch(
+            this.position,
+            this.capture,
+            this.numberedCaptures,
+            this.namedCaptures,
+            this.numberedCaptureIndices,
+            this.namedCaptureIndices,
+            () => backtracker(this, () => this.backtrack())
+        );
+    }
+}

--- a/src/Match/FragmentMatcher.ts
+++ b/src/Match/FragmentMatcher.ts
@@ -1,0 +1,159 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import FragmentInterface from './Fragment/FragmentInterface';
+import FragmentMatch from './FragmentMatch';
+import {
+    Backtracker,
+    NamedCaptureIndices,
+    NamedCaptures,
+    NumberedCaptureIndices,
+    NumberedCaptures,
+} from '../spec/types/match';
+
+/**
+ * Helper class with methods used during matching.
+ */
+export default class FragmentMatcher {
+    /**
+     * Joins all the given matches together into a single FragmentMatch.
+     *
+     * @param {FragmentMatch[]} matches
+     * @param {number} position
+     * @param {Function} backtracker
+     */
+    concatenateMatches(
+        matches: FragmentMatch[],
+        position: number,
+        backtracker: Backtracker
+    ): FragmentMatch {
+        position = matches.length > 0 ? matches[0].getStart() : position;
+        let capture = '';
+        const namedCaptures: NamedCaptures = {};
+        const namedCaptureIndices: NamedCaptureIndices = {};
+        const numberedCaptures: NumberedCaptures = {};
+        const numberedCaptureIndices: NumberedCaptureIndices = {};
+
+        for (const match of matches) {
+            capture += match.getCapture();
+
+            Object.assign(numberedCaptures, match.getNumberedCaptures());
+            Object.assign(namedCaptures, match.getNamedCaptures());
+            Object.assign(
+                numberedCaptureIndices,
+                match.getNumberedCaptureIndices()
+            );
+            Object.assign(namedCaptureIndices, match.getNamedCaptureIndices());
+        }
+
+        return new FragmentMatch(
+            position,
+            capture,
+            numberedCaptures,
+            namedCaptures,
+            numberedCaptureIndices,
+            namedCaptureIndices,
+            backtracker
+        );
+    }
+
+    /**
+     * Matches the given set of component fragments in order, to a single FragmentMatch
+     * (or null if the match fails).
+     *
+     * @param {string} subject
+     * @param {number} position
+     * @param {boolean} isAnchored
+     * @param {FragmentInterface[]} componentFragments
+     */
+    matchComponents(
+        subject: string,
+        position: number,
+        isAnchored: boolean,
+        componentFragments: FragmentInterface[]
+    ): FragmentMatch | null {
+        const componentMatches: FragmentMatch[] = [];
+
+        const backtrack = (): boolean => {
+            if (componentMatches.length === 0) {
+                return false; // We were processing the first component in the list, no backtracking is possible.
+            }
+
+            while (componentMatches.length > 0) {
+                const previousMatch = componentMatches.pop() as FragmentMatch;
+
+                const backtrackedMatch = previousMatch.backtrack();
+
+                if (backtrackedMatch) {
+                    // Replace with the backtracked match in our record.
+                    componentMatches.push(backtrackedMatch);
+
+                    // We've succeeded in backtracking, don't attempt to backtrack further.
+                    break;
+                }
+            }
+
+            if (componentMatches.length === 0) {
+                // We backtracked all the way to the first component and still failed,
+                // no further backtracking is possible.
+                return false;
+            }
+
+            const backtrackedMatch =
+                componentMatches[componentMatches.length - 1];
+
+            // Continue forward again from the place we've backtracked to.
+            position = backtrackedMatch.getEnd();
+
+            return true; // We have successfully backtracked.
+        };
+
+        const tryNextComponent = (): FragmentMatch | null => {
+            while (componentMatches.length < componentFragments.length) {
+                const componentFragment =
+                    componentFragments[componentMatches.length];
+
+                const match = componentFragment.match(
+                    subject,
+                    position,
+                    isAnchored || componentMatches.length > 0
+                );
+
+                if (match) {
+                    // Match succeeded: save it and move to the next component.
+                    componentMatches.push(match);
+
+                    position = match.getEnd();
+
+                    continue;
+                }
+
+                // Otherwise, the match failed, and so we need to try and backtrack...
+                if (!backtrack()) {
+                    return null;
+                }
+            }
+
+            return this.concatenateMatches(
+                componentMatches,
+                position,
+                (): FragmentMatch | null => {
+                    if (!backtrack()) {
+                        return null;
+                    }
+
+                    // Continue forward again from the place we've backtracked to.
+                    return tryNextComponent();
+                }
+            );
+        };
+
+        return tryNextComponent();
+    }
+}

--- a/src/Match/QuantifierMatcher.ts
+++ b/src/Match/QuantifierMatcher.ts
@@ -1,0 +1,104 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import FragmentInterface from './Fragment/FragmentInterface';
+import FragmentMatch from './FragmentMatch';
+import FragmentMatcher from './FragmentMatcher';
+import Exception from '../Exception/Exception';
+
+/**
+ * Helper class with methods used specifically by quantifier matchers.
+ */
+export default class QuantifierMatcher {
+    constructor(private fragmentMatcher: FragmentMatcher) {}
+
+    /**
+     * Matches the given component with maximising (greedy) match logic.
+     *
+     * @param {string} subject
+     * @param {number} position
+     * @param {boolean} isAnchored
+     * @param {FragmentInterface} componentFragment
+     * @param {number} minimumMatches
+     * @param {number|null} maximumMatches
+     * @param {Function} backtracker
+     */
+    matchMaximising(
+        subject: string,
+        position: number,
+        isAnchored: boolean,
+        componentFragment: FragmentInterface,
+        minimumMatches: number,
+        maximumMatches: number | null,
+        backtracker: (matches: FragmentMatch[]) => FragmentMatch | null
+    ): FragmentMatch | null {
+        let match: FragmentMatch | null;
+        const matches: FragmentMatch[] = [];
+
+        while (
+            (match = componentFragment.match(subject, position, isAnchored))
+        ) {
+            if (maximumMatches !== null && matches.length > maximumMatches) {
+                /*
+                 * Maximum reached, don't try to match any more.
+                 * Note that it would actually be valid for there to be more matches,
+                 * the rest of the pattern is then free to match against them.
+                 */
+                break;
+            }
+
+            matches.push(match);
+
+            // Move past this match.
+            position = match.getEnd();
+        }
+
+        if (matches.length < minimumMatches) {
+            // We didn't meet the minimum required number of matches,
+            // so the entire match is a failure.
+            return null;
+        }
+
+        return this.fragmentMatcher.concatenateMatches(matches, position, () =>
+            backtracker(matches)
+        );
+    }
+
+    /**
+     * Parses the given quantifier string to a (max, min) matches tuple.
+     *
+     * @param {string} quantifier
+     */
+    parseQuantifier(quantifier: string): {
+        minimumMatches: number;
+        maximumMatches: number | null;
+    } {
+        let minimumMatches: number;
+        let maximumMatches: number | null;
+
+        switch (quantifier) {
+            case '?':
+                minimumMatches = 0;
+                maximumMatches = 1;
+                break;
+            case '*':
+                minimumMatches = 0;
+                maximumMatches = null;
+                break;
+            case '+':
+                minimumMatches = 1;
+                maximumMatches = null;
+                break;
+            default:
+                throw new Exception(`Unsupported quantifier "${quantifier}"`);
+        }
+
+        return { minimumMatches, maximumMatches };
+    }
+}

--- a/src/Matcher.ts
+++ b/src/Matcher.ts
@@ -37,15 +37,14 @@ export default class Matcher {
         const matches: Match[] = [];
         let position = start;
 
-        while ((match = this.pattern.match(subject, position))) {
+        while (
+            position <= subject.length &&
+            (match = this.pattern.match(subject, position))
+        ) {
             matches.push(match);
 
             // Start the next match just after this one.
-            position =
-                match.getEnd() +
-                // Prevent infinite loop if match is zero-width -
-                // ensure we always advance by at least 1 character.
-                (match.getLength() === 0 ? 1 : 0);
+            position = match.getNextMatchPosition();
         }
 
         return matches;

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -16,6 +16,7 @@ export const DEFAULT_FLAGS: Flags = {
     dotAll: false,
     extended: false,
     multiline: false,
+    optimise: true,
 };
 
 /**

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -13,6 +13,7 @@ import { Flags } from './declarations/types';
 export const DEFAULT_FLAGS: Flags = {
     anchored: false,
     caseless: false,
+    dotAll: false,
     extended: false,
     multiline: false,
 };

--- a/src/PatternFactory.ts
+++ b/src/PatternFactory.ts
@@ -7,7 +7,9 @@
  * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
  */
 
+import { Flags } from './declarations/types';
 import Pattern from './Pattern';
+import PatternFragment from './Match/Fragment/PatternFragment';
 
 /**
  * Creates Pattern-related objects.
@@ -16,19 +18,10 @@ export default class PatternFactory {
     /**
      * Creates a new Pattern.
      *
-     * @param {RegExp} regex
-     * @param {Array<number | string>} capturingGroupNames
-     * @param {number[]} patternToEmulatedNumberedGroupIndex
+     * @param {PatternFragment} patternFragment
+     * @param {Flags} flags
      */
-    createPattern(
-        regex: RegExp,
-        capturingGroupNames: Array<number | string>,
-        patternToEmulatedNumberedGroupIndex: number[]
-    ): Pattern {
-        return new Pattern(
-            regex,
-            capturingGroupNames,
-            patternToEmulatedNumberedGroupIndex
-        );
+    createPattern(patternFragment: PatternFragment, flags: Flags): Pattern {
+        return new Pattern(patternFragment, flags);
     }
 }

--- a/src/declarations/types.d.ts
+++ b/src/declarations/types.d.ts
@@ -10,6 +10,7 @@
 export type Flags = {
     anchored?: boolean;
     caseless?: boolean;
+    dotAll?: boolean;
     extended?: boolean;
     multiline?: boolean;
 };

--- a/src/declarations/types.d.ts
+++ b/src/declarations/types.d.ts
@@ -13,6 +13,7 @@ export type Flags = {
     dotAll?: boolean;
     extended?: boolean;
     multiline?: boolean;
+    optimise?: boolean;
 };
 
 export type RegExpMatchArrayIndices = [[number, number]] & {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,9 @@
  */
 
 import Emulator from './Emulator';
+import accelerateRawPassSpec from './spec/intermediateOptimiser/accelerateRawPass';
 import astToIntermediateTranspilerSpec from './spec/astToIntermediate';
+import compileRawPassSpec from './spec/intermediateOptimiser/compileRawPass';
 import intermediateToPatternTranspilerSpec from './spec/intermediateToPattern';
 import parserGrammarSpec from './spec/parserGrammar';
 import parsing = require('parsing');
@@ -19,6 +21,7 @@ const emulator = new Emulator(
     transpiler,
     parserGrammarSpec,
     astToIntermediateTranspilerSpec,
+    [accelerateRawPassSpec, compileRawPassSpec],
     intermediateToPatternTranspilerSpec
 );
 

--- a/src/spec/base/intermediateOptimiser.ts
+++ b/src/spec/base/intermediateOptimiser.ts
@@ -1,0 +1,267 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import {
+    I_ALTERNATION,
+    I_ALTERNATIVE,
+    I_CAPTURING_GROUP,
+    I_COMPONENT,
+    I_MAXIMISING_QUANTIFIER,
+    I_MINIMISING_QUANTIFIER,
+    I_NAMED_CAPTURING_GROUP,
+    I_NODE,
+    I_NON_CAPTURING_GROUP,
+    I_NOOP,
+    I_PATTERN,
+    I_POSSESSIVE_QUANTIFIER,
+    I_RAW_CHUNK,
+    I_RAW_REGEX,
+} from '../types/intermediateRepresentation';
+import { N_NODE } from '../types/ast';
+
+type Interpret = (node: N_NODE) => I_NODE;
+
+/**
+ * Joins the chunks of any sequential I_RAW_REGEX nodes together
+ * to facilitate optimisation.
+ *
+ * @param {I_COMPONENT[]} nodes
+ * @param {I_RAW_CHUNK|null} glue
+ * @param {Function} unpackItem
+ * @param {Function} repackItem
+ */
+export const concatenateRawRegexNodes = <T extends I_COMPONENT>(
+    nodes: T[],
+    glue: I_RAW_CHUNK | null = null,
+    unpackItem = (node: T): I_COMPONENT | null => node,
+    repackItem = (node: I_RAW_REGEX): T => node as unknown as T
+) => {
+    let currentRunChunks: I_RAW_CHUNK[] = [];
+    const resultNodes: T[] = [];
+
+    const addRunItem = () => {
+        resultNodes.push(
+            repackItem({
+                'name': 'I_RAW_REGEX',
+                'chunks': currentRunChunks,
+            })
+        );
+    };
+
+    for (const node of nodes) {
+        const item = unpackItem(node);
+
+        if (item !== null && item.name === 'I_RAW_REGEX') {
+            if (glue !== null && currentRunChunks.length > 0) {
+                currentRunChunks.push(glue);
+            }
+
+            currentRunChunks.push(...(item as I_RAW_REGEX).chunks);
+        } else if (currentRunChunks.length > 0) {
+            addRunItem();
+
+            // Reset for the next run.
+            currentRunChunks = [];
+
+            // Make sure we add the non-run item that ended the run to the result too.
+            resultNodes.push(node);
+        } else {
+            // When we're outside a run, just add the item to the result.
+            resultNodes.push(node);
+        }
+    }
+
+    // Clear up any leftovers.
+    if (currentRunChunks.length > 0) {
+        addRunItem();
+    }
+
+    return resultNodes;
+};
+
+/**
+ * Optimises a single component as much as possible.
+ *
+ * @param {I_COMPONENT} component
+ * @param {Function} interpret
+ * @param {Function} buildOptimised
+ * @param {Function} buildUnoptimised
+ */
+export const optimiseComponent = <T extends I_COMPONENT>(
+    component: I_COMPONENT,
+    interpret: Interpret,
+    buildOptimised: (rawRegexNode: I_RAW_REGEX) => I_RAW_REGEX,
+    buildUnoptimised: (optimisedComponent: I_COMPONENT) => T
+): T | I_RAW_REGEX => {
+    // Apply optimisations to the component.
+    const optimisedComponent = interpret(component);
+
+    if (optimisedComponent.name === 'I_RAW_REGEX') {
+        const rawRegexNode = optimisedComponent as I_RAW_REGEX;
+
+        // Fully optimised mode - component has been compiled down
+        // to a native regex fragment, so we can generate a native fragment for the whole thing.
+        return buildOptimised(rawRegexNode);
+    }
+
+    // Partially-optimised mode: component has been optimised as much as possible,
+    // but we've been unable to produce a single raw regex fragment.
+    return buildUnoptimised(optimisedComponent);
+};
+
+/**
+ * Optimises a list of components as much as possible.
+ *
+ * @param {I_COMPONENT[]} components
+ * @param {Function} interpret
+ * @param {Function} buildOptimised
+ * @param {Function} buildUnoptimised
+ */
+export const optimiseComponents = <T extends I_COMPONENT>(
+    components: I_COMPONENT[],
+    interpret: Interpret,
+    buildOptimised: (rawRegexNode: I_RAW_REGEX) => I_RAW_REGEX,
+    buildUnoptimised: (concatenatedComponents: I_COMPONENT[]) => T
+): T | I_RAW_REGEX => {
+    // Apply optimisations to all components.
+    const optimisedComponents = components.map((node: I_COMPONENT) =>
+        interpret(node)
+    );
+
+    // Now combine any runs of components together "ab...".
+    const concatenatedComponents =
+        concatenateRawRegexNodes(optimisedComponents);
+
+    if (
+        concatenatedComponents.length === 1 &&
+        concatenatedComponents[0].name === 'I_RAW_REGEX'
+    ) {
+        const rawRegexNode = concatenatedComponents[0] as I_RAW_REGEX;
+
+        // Fully optimised mode - entire contents inside group have been compiled down
+        // to a native regex fragment, so we can generate a native fragment for the whole thing.
+        return buildOptimised(rawRegexNode);
+    }
+
+    // Partially-optimised mode: components have been optimised as much as possible,
+    // but we've been unable to produce a single raw regex fragment.
+    return buildUnoptimised(concatenatedComponents);
+};
+
+/**
+ * Transpiler library spec to optimise a regular expression Intermediate Representation (IR)
+ * to a new IR that will use native JavaScript regex features as much as possible.
+ */
+export default {
+    nodes: {
+        'I_ALTERNATION': (
+            node: I_ALTERNATION,
+            interpret: Interpret
+        ): I_ALTERNATION => {
+            return {
+                'name': 'I_ALTERNATION',
+                'alternatives': node.alternatives.map((node: I_ALTERNATIVE) =>
+                    interpret(node)
+                ) as I_ALTERNATIVE[],
+            };
+        },
+        'I_ALTERNATIVE': (
+            node: I_ALTERNATIVE,
+            interpret: Interpret
+        ): I_ALTERNATIVE => {
+            return {
+                'name': 'I_ALTERNATIVE',
+                'components': node.components.map((node: I_COMPONENT) =>
+                    interpret(node)
+                ),
+            };
+        },
+        'I_CAPTURING_GROUP': (
+            node: I_CAPTURING_GROUP,
+            interpret: Interpret
+        ): I_CAPTURING_GROUP => {
+            return {
+                'name': 'I_CAPTURING_GROUP',
+                'groupIndex': node.groupIndex,
+                'components': node.components.map((node: I_COMPONENT) =>
+                    interpret(node)
+                ),
+            };
+        },
+        'I_MAXIMISING_QUANTIFIER': (
+            node: I_MAXIMISING_QUANTIFIER,
+            interpret: Interpret
+        ): I_MAXIMISING_QUANTIFIER => {
+            return {
+                'name': 'I_MAXIMISING_QUANTIFIER',
+                'component': interpret(node.component),
+                'quantifier': node.quantifier,
+            };
+        },
+        'I_MINIMISING_QUANTIFIER': (
+            node: I_MINIMISING_QUANTIFIER,
+            interpret: Interpret
+        ): I_MINIMISING_QUANTIFIER => {
+            return {
+                'name': 'I_MINIMISING_QUANTIFIER',
+                'component': interpret(node.component),
+                'quantifier': node.quantifier,
+            };
+        },
+        'I_NAMED_CAPTURING_GROUP': (
+            node: I_NAMED_CAPTURING_GROUP,
+            interpret: Interpret
+        ): I_NAMED_CAPTURING_GROUP => {
+            return {
+                'name': 'I_NAMED_CAPTURING_GROUP',
+                'groupIndex': node.groupIndex,
+                'groupName': node.groupName,
+                'components': node.components.map((node: I_COMPONENT) =>
+                    interpret(node)
+                ),
+            };
+        },
+        'I_NON_CAPTURING_GROUP': (
+            node: I_NON_CAPTURING_GROUP,
+            interpret: Interpret
+        ): I_NON_CAPTURING_GROUP => {
+            return {
+                'name': 'I_NON_CAPTURING_GROUP',
+                'components': node.components.map((node: I_COMPONENT) =>
+                    interpret(node)
+                ),
+            };
+        },
+        'I_NOOP': (node: I_NOOP): I_NOOP => {
+            return node;
+        },
+        'I_PATTERN': (node: I_PATTERN, interpret: Interpret): I_PATTERN => {
+            return {
+                'name': 'I_PATTERN',
+                'capturingGroups': node.capturingGroups,
+                'components': node.components.map((node: I_COMPONENT) =>
+                    interpret(node)
+                ),
+            };
+        },
+        'I_POSSESSIVE_QUANTIFIER': (
+            node: I_POSSESSIVE_QUANTIFIER,
+            interpret: Interpret
+        ): I_POSSESSIVE_QUANTIFIER => {
+            return {
+                'name': 'I_POSSESSIVE_QUANTIFIER',
+                'component': interpret(node.component),
+                'quantifier': node.quantifier,
+            };
+        },
+        'I_RAW_REGEX': (node: I_RAW_REGEX): I_RAW_REGEX => {
+            return node;
+        },
+    },
+};

--- a/src/spec/intermediateOptimiser/accelerateRawPass.ts
+++ b/src/spec/intermediateOptimiser/accelerateRawPass.ts
@@ -1,0 +1,385 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import {
+    I_ALTERNATION,
+    I_ALTERNATIVE,
+    I_CAPTURING_GROUP,
+    I_COMPONENT,
+    I_MAXIMISING_QUANTIFIER,
+    I_MINIMISING_QUANTIFIER,
+    I_NAMED_CAPTURING_GROUP,
+    I_NODE,
+    I_NON_CAPTURING_GROUP,
+    I_PATTERN,
+    I_POSSESSIVE_QUANTIFIER,
+    I_RAW_REGEX,
+} from '../types/intermediateRepresentation';
+import base, {
+    concatenateRawRegexNodes,
+    optimiseComponent,
+    optimiseComponents,
+} from '../base/intermediateOptimiser';
+import { N_NODE } from '../types/ast';
+
+type Interpret = (node: N_NODE) => I_NODE;
+
+/**
+ * Transpiler library spec to optimise a regular expression Intermediate Representation (IR)
+ * to a new IR that will use native JavaScript regex features as much as possible.
+ */
+export default {
+    nodes: {
+        ...base.nodes,
+
+        'I_ALTERNATION': (
+            node: I_ALTERNATION,
+            interpret: Interpret
+        ): I_ALTERNATION | I_RAW_REGEX => {
+            // Apply optimisations to all alternatives.
+            // Note this will combine any raw regex fragments within each alternative if possible.
+            const optimisedAlternatives = node.alternatives.map(
+                (node: I_ALTERNATIVE) => interpret(node)
+            ) as I_ALTERNATIVE[];
+
+            // Now combine any runs of alternatives into raw alternations "a|b|...".
+            const concatenatedAlternatives =
+                concatenateRawRegexNodes<I_ALTERNATIVE>(
+                    optimisedAlternatives,
+                    {
+                        'name': 'I_RAW_CHARS',
+                        'chars': '|',
+                    },
+                    (node): I_RAW_REGEX | null => {
+                        if (node.components.length === 0) {
+                            // Optimise the special case of an empty alternative in the alternation.
+                            return {
+                                'name': 'I_RAW_REGEX',
+                                'chunks': [
+                                    {
+                                        'name': 'I_RAW_NOOP',
+                                    },
+                                ],
+                            };
+                        }
+
+                        return node.components.length === 1 &&
+                            node.components[0].name === 'I_RAW_REGEX'
+                            ? (node.components[0] as I_RAW_REGEX)
+                            : null;
+                    },
+                    (node) => ({
+                        'name': 'I_ALTERNATIVE',
+                        'components': [node],
+                    })
+                );
+
+            if (
+                concatenatedAlternatives.length === 1 &&
+                concatenatedAlternatives[0].components.length === 1 &&
+                concatenatedAlternatives[0].components[0].name === 'I_RAW_REGEX'
+            ) {
+                const rawRegexNode = concatenatedAlternatives[0]
+                    .components[0] as I_RAW_REGEX;
+
+                // Fully optimised mode - entire contents of alternation have been compiled down
+                // to a native regex fragment, so we have a native alternation to use.
+                return {
+                    'name': 'I_RAW_REGEX',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_NESTED',
+                            'node': rawRegexNode,
+                        },
+                    ],
+                };
+            }
+
+            // Partially-optimised mode: alternatives have been optimised as much as possible,
+            // but we've been unable to produce a single raw regex fragment.
+            return {
+                'name': 'I_ALTERNATION',
+                'alternatives': concatenatedAlternatives,
+            };
+        },
+        'I_ALTERNATIVE': (
+            node: I_ALTERNATIVE,
+            interpret: Interpret
+        ): I_ALTERNATIVE => {
+            // Apply optimisations to all components.
+            const optimisedComponents = node.components.map(
+                (node: I_COMPONENT) => interpret(node)
+            );
+
+            // Now combine any runs of components together "ab...".
+            const concatenatedComponents =
+                concatenateRawRegexNodes(optimisedComponents);
+
+            return {
+                'name': 'I_ALTERNATIVE',
+                'components': concatenatedComponents,
+            };
+        },
+        'I_CAPTURING_GROUP': (
+            node: I_CAPTURING_GROUP,
+            interpret: Interpret
+        ): I_CAPTURING_GROUP | I_RAW_REGEX => {
+            return optimiseComponents<I_CAPTURING_GROUP>(
+                node.components,
+                interpret,
+                (rawRegexNode) => {
+                    // Fully optimised mode - entire contents inside capturing group have been compiled down
+                    // to a native regex fragment, so we can wrap it all in a native capturing group.
+                    return {
+                        'name': 'I_RAW_REGEX',
+                        'chunks': [
+                            {
+                                'name': 'I_RAW_CAPTURE',
+                                'groupIndex': node.groupIndex,
+                                'chunks': [
+                                    {
+                                        'name': 'I_RAW_NESTED',
+                                        'node': rawRegexNode,
+                                    },
+                                ],
+                            },
+                        ],
+                    };
+                },
+                (concatenatedComponents) => {
+                    // Partially-optimised mode: components have been optimised as much as possible,
+                    // but we've been unable to produce a single raw regex fragment.
+                    return {
+                        'name': 'I_CAPTURING_GROUP',
+                        'groupIndex': node.groupIndex,
+                        'components': concatenatedComponents,
+                    };
+                }
+            );
+        },
+        'I_MAXIMISING_QUANTIFIER': (
+            node: I_MAXIMISING_QUANTIFIER,
+            interpret: Interpret
+        ): I_MAXIMISING_QUANTIFIER | I_RAW_REGEX => {
+            return optimiseComponent<I_MAXIMISING_QUANTIFIER>(
+                node.component,
+                interpret,
+                (rawRegexNode) => {
+                    // Fully optimised mode - component has been compiled down
+                    // to a native regex fragment, so we can just append the correct native quantifier.
+                    return {
+                        'name': 'I_RAW_REGEX',
+                        'chunks': [
+                            {
+                                'name': 'I_RAW_NESTED',
+                                'node': rawRegexNode,
+                            },
+                            {
+                                'name': 'I_RAW_CHARS',
+                                'chars': node.quantifier,
+                            },
+                        ],
+                    };
+                },
+                (optimisedComponent) => {
+                    // Partially-optimised mode: component has been optimised as much as possible,
+                    // but we've been unable to produce a single raw regex fragment.
+                    return {
+                        'name': 'I_MAXIMISING_QUANTIFIER',
+                        'component': optimisedComponent,
+                        'quantifier': node.quantifier,
+                    };
+                }
+            );
+        },
+        'I_MINIMISING_QUANTIFIER': (
+            node: I_MINIMISING_QUANTIFIER,
+            interpret: Interpret
+        ): I_MINIMISING_QUANTIFIER | I_RAW_REGEX => {
+            return optimiseComponent<I_MINIMISING_QUANTIFIER>(
+                node.component,
+                interpret,
+                (rawRegexNode) => {
+                    // Fully optimised mode - component has been compiled down
+                    // to a native regex fragment, so we can just append the correct native quantifier.
+                    return {
+                        'name': 'I_RAW_REGEX',
+                        'chunks': [
+                            {
+                                'name': 'I_RAW_NESTED',
+                                'node': rawRegexNode,
+                            },
+                            {
+                                'name': 'I_RAW_CHARS',
+                                'chars': node.quantifier + '?',
+                            },
+                        ],
+                    };
+                },
+                (optimisedComponent) => {
+                    // Partially-optimised mode: component has been optimised as much as possible,
+                    // but we've been unable to produce a single raw regex fragment.
+                    return {
+                        'name': 'I_MINIMISING_QUANTIFIER',
+                        'component': optimisedComponent,
+                        'quantifier': node.quantifier,
+                    };
+                }
+            );
+        },
+        'I_NAMED_CAPTURING_GROUP': (
+            node: I_NAMED_CAPTURING_GROUP,
+            interpret: Interpret
+        ): I_NAMED_CAPTURING_GROUP | I_RAW_REGEX => {
+            return optimiseComponents<I_NAMED_CAPTURING_GROUP>(
+                node.components,
+                interpret,
+                (rawRegexNode) => {
+                    // Fully optimised mode - entire contents inside capturing group have been compiled down
+                    // to a native regex fragment, so we can wrap it all in a native named capturing group.
+                    return {
+                        'name': 'I_RAW_REGEX',
+                        'chunks': [
+                            {
+                                'name': 'I_RAW_NAMED_CAPTURE',
+                                'groupIndex': node.groupIndex,
+                                'groupName': node.groupName,
+                                'chunks': [
+                                    {
+                                        'name': 'I_RAW_NESTED',
+                                        'node': rawRegexNode,
+                                    },
+                                ],
+                            },
+                        ],
+                    };
+                },
+                (concatenatedComponents) => {
+                    // Partially-optimised mode: components have been optimised as much as possible,
+                    // but we've been unable to produce a single raw regex fragment.
+                    return {
+                        'name': 'I_NAMED_CAPTURING_GROUP',
+                        'groupIndex': node.groupIndex,
+                        'groupName': node.groupName,
+                        'components': concatenatedComponents,
+                    };
+                }
+            );
+        },
+        'I_NON_CAPTURING_GROUP': (
+            node: I_NON_CAPTURING_GROUP,
+            interpret: Interpret
+        ): I_NON_CAPTURING_GROUP | I_RAW_REGEX => {
+            return optimiseComponents<I_NON_CAPTURING_GROUP>(
+                node.components,
+                interpret,
+                (rawRegexNode) => {
+                    // Fully optimised mode - entire contents inside capturing group have been compiled down
+                    // to a native regex fragment, so we can wrap it all in a native non-capturing group.
+                    return {
+                        'name': 'I_RAW_REGEX',
+                        'chunks': [
+                            {
+                                'name': 'I_RAW_NON_CAPTURE',
+                                'chunks': [
+                                    {
+                                        'name': 'I_RAW_NESTED',
+                                        'node': rawRegexNode,
+                                    },
+                                ],
+                            },
+                        ],
+                    };
+                },
+                (concatenatedComponents) => {
+                    // Partially-optimised mode: components have been optimised as much as possible,
+                    // but we've been unable to produce a single raw regex fragment.
+                    return {
+                        'name': 'I_NON_CAPTURING_GROUP',
+                        'components': concatenatedComponents,
+                    };
+                }
+            );
+        },
+        'I_PATTERN': (node: I_PATTERN, interpret: Interpret): I_PATTERN => {
+            // Apply optimisations to all components.
+            const optimisedComponents = node.components.map(
+                (node: I_COMPONENT) => interpret(node)
+            );
+
+            // Now combine any runs of components together "ab...".
+            const concatenatedComponents =
+                concatenateRawRegexNodes(optimisedComponents);
+
+            // Note that we always return an I_PATTERN node even if its entire contents
+            // have been optimised to a single raw regex fragment.
+            return {
+                'name': 'I_PATTERN',
+                'capturingGroups': node.capturingGroups,
+                'components': concatenatedComponents,
+            };
+        },
+        'I_POSSESSIVE_QUANTIFIER': (
+            node: I_POSSESSIVE_QUANTIFIER,
+            interpret: Interpret
+        ): I_POSSESSIVE_QUANTIFIER | I_RAW_REGEX => {
+            return optimiseComponent<I_POSSESSIVE_QUANTIFIER>(
+                node.component,
+                interpret,
+                (rawRegexNode) => {
+                    // Fully optimised mode - component has been compiled down
+                    // to a native regex fragment, so we can just emulate with a native lookahead.
+                    return {
+                        'name': 'I_RAW_REGEX',
+                        'chunks': [
+                            {
+                                'name': 'I_RAW_CHARS',
+                                'chars': '(?=',
+                            },
+                            {
+                                // Use an "emulated"-type chunk as it does not relate
+                                // to a capturing group in the original pattern.
+                                'name': 'I_RAW_GHOST_CAPTURE',
+                                'id': 'atomic',
+                                'chunks': [
+                                    {
+                                        'name': 'I_RAW_NESTED',
+                                        'node': rawRegexNode,
+                                    },
+                                    {
+                                        'name': 'I_RAW_CHARS',
+                                        'chars': node.quantifier,
+                                    },
+                                ],
+                            },
+                            {
+                                'name': 'I_RAW_CHARS',
+                                'chars': ')',
+                            },
+                            // Concatenate the capturing group index on the end.
+                            {
+                                'name': 'I_RAW_BACKREFERENCE',
+                                'id': 'atomic',
+                            },
+                        ],
+                    };
+                },
+                (optimisedComponent) => {
+                    // Partially-optimised mode: component has been optimised as much as possible,
+                    // but we've been unable to produce a single raw regex fragment.
+                    return {
+                        'name': 'I_POSSESSIVE_QUANTIFIER',
+                        'component': optimisedComponent,
+                        'quantifier': node.quantifier,
+                    };
+                }
+            );
+        },
+    },
+};

--- a/src/spec/intermediateOptimiser/compileRawPass.ts
+++ b/src/spec/intermediateOptimiser/compileRawPass.ts
@@ -1,0 +1,218 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import {
+    I_NODE,
+    I_RAW_BACKREFERENCE,
+    I_RAW_CAPTURE,
+    I_RAW_CHARS,
+    I_RAW_GHOST_CAPTURE,
+    I_RAW_NAMED_CAPTURE,
+    I_RAW_NESTED,
+    I_RAW_NON_CAPTURE,
+    I_RAW_REGEX,
+} from '../types/intermediateRepresentation';
+import base from '../base/intermediateOptimiser';
+import { N_NODE } from '../types/ast';
+import Exception from '../../Exception/Exception';
+
+type Interpret = (node: N_NODE, context?: object) => I_NODE | string;
+
+type Context = {
+    /**
+     * Fetches a previously-added capturing or ghost-capturing group's index by its ID.
+     *
+     * @param {string} id
+     * @throws {Exception} Throws when no capturing group has been added with the given ID.
+     */
+    getCapturingGroupIndex(id: string): number;
+
+    /**
+     * Records a capturing group for the current raw regex context,
+     * which maps to a capturing group in the original PCRE pattern.
+     * Optionally stores its index against the given ID, so that it may be fetched later
+     * for a backreference (from N_RAW_BACKREFERENCE).
+     *
+     * @param {number} patternIndex
+     * @param {string=} id
+     */
+    recordCapturingGroup(patternIndex: number, id?: string): void;
+
+    /**
+     * Records a "ghost" capturing group, which does _not_ map to a capturing group
+     * in the original PCRE pattern, but which is captured for another emulation-related reason.
+     *
+     * For example, atomic groups are emulated with a capturing group inside a lookahead -
+     * the capturing group's capture is not actually returned to the user,
+     * only used by a backreference just after it.
+     *
+     * Optionally stores its index against the given ID, so that it may be fetched later
+     * for a backreference (from N_RAW_BACKREFERENCE).
+     *
+     * @param {string=} id
+     */
+    recordGhostCapturingGroup(id?: string): void;
+};
+
+const hasOwn = {}.hasOwnProperty;
+
+/**
+ * Transpiler library spec to optimise a regular expression Intermediate Representation (IR)
+ * using complex I_RAW_REGEX node trees to simple I_RAW_REGEX-wrapped I_RAW_OPTIMISED nodes.
+ */
+export default {
+    nodes: {
+        ...base.nodes,
+
+        'I_RAW_BACKREFERENCE': (
+            node: I_RAW_BACKREFERENCE,
+            interpret: Interpret,
+            context: Context
+        ): string => {
+            return '\\' + context.getCapturingGroupIndex(node.id);
+        },
+        'I_RAW_CAPTURE': (
+            node: I_RAW_CAPTURE,
+            interpret: Interpret,
+            context: Context
+        ): string => {
+            context.recordCapturingGroup(node.groupIndex, node.id);
+
+            return (
+                // Add a native capturing group around.
+                '(' +
+                node.chunks.map((chunk) => interpret(chunk, context)).join('') +
+                ')'
+            );
+        },
+        'I_RAW_CHARS': (node: I_RAW_CHARS): string => {
+            return node.chars;
+        },
+        'I_RAW_GHOST_CAPTURE': (
+            node: I_RAW_GHOST_CAPTURE,
+            interpret: Interpret,
+            context: Context
+        ): string => {
+            context.recordGhostCapturingGroup(node.id);
+
+            return (
+                // Add a native capturing group around. Note we don't use a native non-capturing group,
+                // as we still need the data captured (e.g. for use by a backreference),
+                // it just doesn't relate to a capturing group in the original PCRE pattern.
+                '(' +
+                node.chunks.map((chunk) => interpret(chunk, context)).join('') +
+                ')'
+            );
+        },
+        'I_RAW_NAMED_CAPTURE': (
+            node: I_RAW_NAMED_CAPTURE,
+            interpret: Interpret,
+            context: Context
+        ): string => {
+            context.recordCapturingGroup(node.groupIndex, node.id);
+
+            return (
+                // Add a native named capturing group around.
+                '(?<' +
+                node.groupName +
+                '>' +
+                node.chunks.map((chunk) => interpret(chunk, context)).join('') +
+                ')'
+            );
+        },
+        'I_RAW_NESTED': (node: I_RAW_NESTED, interpret: Interpret): string => {
+            if (node.node.name !== 'I_RAW_REGEX') {
+                throw new Exception('Expected an I_RAW_REGEX at this point');
+            }
+
+            const rawRegexNode = node.node as I_RAW_REGEX;
+
+            return rawRegexNode.chunks
+                .map((chunk) => interpret(chunk))
+                .join('');
+        },
+        'I_RAW_NON_CAPTURE': (
+            node: I_RAW_NON_CAPTURE,
+            interpret: Interpret
+        ): string => {
+            return (
+                // Add a native non-capturing group around.
+                '(?:' +
+                node.chunks.map((chunk) => interpret(chunk)).join('') +
+                ')'
+            );
+        },
+        'I_RAW_NOOP': (): string => {
+            return '';
+        },
+        'I_RAW_REGEX': (
+            node: I_RAW_REGEX,
+            interpret: Interpret
+        ): I_RAW_REGEX => {
+            const capturingGroupIdToIndex: { [id: string]: number } = {};
+            const patternToEmulatedNumberedGroupIndex: {
+                [key: number]: number;
+            } = {};
+            let emulatedCapturingGroupCount = 1;
+
+            const context: Context = {
+                /**
+                 * @inheritDoc
+                 */
+                getCapturingGroupIndex(id: string): number {
+                    if (!hasOwn.call(capturingGroupIdToIndex, id)) {
+                        throw new Exception(
+                            `No capturing group defined with id ${id} for this I_RAW_REGEX`
+                        );
+                    }
+
+                    return capturingGroupIdToIndex[id];
+                },
+
+                /**
+                 * @inheritDoc
+                 */
+                recordCapturingGroup(patternIndex: number, id?: string): void {
+                    const index = emulatedCapturingGroupCount++;
+
+                    if (id !== undefined) {
+                        capturingGroupIdToIndex[id] = index;
+                    }
+
+                    patternToEmulatedNumberedGroupIndex[patternIndex] = index;
+                },
+
+                /**
+                 * @inheritDoc
+                 */
+                recordGhostCapturingGroup(id?: string): void {
+                    const index = emulatedCapturingGroupCount++;
+
+                    if (id !== undefined) {
+                        capturingGroupIdToIndex[id] = index;
+                    }
+                },
+            };
+
+            return {
+                'name': 'I_RAW_REGEX',
+                'chunks': [
+                    {
+                        'name': 'I_RAW_OPTIMISED',
+                        'chars': node.chunks
+                            .map((chunk) => interpret(chunk, context))
+                            .join(''),
+                        'patternToEmulatedNumberedGroupIndex':
+                            patternToEmulatedNumberedGroupIndex,
+                    },
+                ],
+            };
+        },
+    },
+};

--- a/src/spec/intermediateToPattern.ts
+++ b/src/spec/intermediateToPattern.ts
@@ -117,6 +117,7 @@ export default {
 
             return new MinimisingQuantifierFragment(
                 context.fragmentMatcher,
+                context.quantifierMatcher,
                 componentFragment,
                 minimumMatches,
                 maximumMatches

--- a/src/spec/parserGrammar.ts
+++ b/src/spec/parserGrammar.ts
@@ -12,7 +12,7 @@ import {
     N_CHARACTER,
     N_CHARACTER_CLASS,
     N_COMPONENT,
-} from './astToIntermediate';
+} from './types/ast';
 
 /**
  * Parsing library grammar for parsing PCRE regular expressions to an AST.

--- a/src/spec/types/ast.ts
+++ b/src/spec/types/ast.ts
@@ -1,0 +1,88 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+/**
+ * AST-related types.
+ *
+ * AST node names start with N_*.
+ */
+
+export type N_ALTERNATION = N_COMPONENT & {
+    name: 'N_ALTERNATION';
+    alternatives: N_ALTERNATIVE[];
+};
+export type N_ALTERNATIVE = N_COMPONENT & {
+    name: 'N_ALTERNATIVE';
+    components: N_COMPONENT[];
+};
+export type N_CAPTURING_GROUP = N_COMPONENT & {
+    name: 'N_CAPTURING_GROUP';
+    components: N_COMPONENT[];
+};
+export type N_CHARACTER = N_CHARACTER_CLASS_COMPONENT & {
+    name: 'N_CHARACTER';
+    char: string;
+};
+export type N_CHARACTER_CLASS = N_COMPONENT & {
+    name: 'N_CHARACTER_CLASS';
+    components: N_CHARACTER_CLASS_COMPONENT[];
+    negated: boolean;
+};
+export type N_CHARACTER_CLASS_COMPONENT = N_COMPONENT;
+export type N_CHARACTER_RANGE = N_CHARACTER_CLASS_COMPONENT & {
+    name: 'N_CHARACTER_RANGE';
+    from: string;
+    to: string;
+};
+export type N_COMPONENT = N_NODE;
+export type N_DOT = N_COMPONENT & {
+    name: 'N_DOT';
+};
+export type N_GENERIC_CHAR = N_COMPONENT & {
+    name: 'N_GENERIC_CHAR';
+    type: string;
+};
+export type N_LITERAL = N_COMPONENT & { name: 'N_LITERAL'; text: string };
+export type N_MAXIMISING_QUANTIFIER = N_COMPONENT & {
+    name: 'N_MAXIMISING_QUANTIFIER';
+    quantifier: string;
+    component: N_COMPONENT;
+};
+export type N_MINIMISING_QUANTIFIER = N_COMPONENT & {
+    name: 'N_MINIMISING_QUANTIFIER';
+    quantifier: string;
+    component: N_COMPONENT;
+};
+export type N_NAMED_CAPTURING_GROUP = N_COMPONENT & {
+    name: 'N_NAMED_CAPTURING_GROUP';
+    components: N_COMPONENT[];
+    groupName: string;
+};
+export type N_NODE = { name: string };
+export type N_NON_CAPTURING_GROUP = N_COMPONENT & {
+    name: 'N_NON_CAPTURING_GROUP';
+    components: N_COMPONENT[];
+};
+export type N_PATTERN = N_NODE & {
+    name: 'N_PATTERN';
+    components: N_COMPONENT[];
+};
+export type N_POSSESSIVE_QUANTIFIER = N_COMPONENT & {
+    name: 'N_POSSESSIVE_QUANTIFIER';
+    quantifier: string;
+    component: N_COMPONENT;
+};
+export type N_SIMPLE_ASSERTION = N_COMPONENT & {
+    name: 'N_SIMPLE_ASSERTION';
+    assertion: string;
+};
+export type N_WHITESPACE = N_COMPONENT & {
+    name: 'N_WHITESPACE';
+    chars: string;
+};

--- a/src/spec/types/intermediateRepresentation.ts
+++ b/src/spec/types/intermediateRepresentation.ts
@@ -1,0 +1,120 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+/**
+ * Intermediate Representation (IR)-related types.
+ *
+ * IR node names start with I_*.
+ */
+
+export type I_ALTERNATION = I_COMPONENT & {
+    name: 'I_ALTERNATION';
+    alternatives: I_ALTERNATIVE[];
+};
+export type I_ALTERNATIVE = I_COMPONENT & {
+    name: 'I_ALTERNATIVE';
+    components: I_COMPONENT[];
+};
+export type I_CAPTURING_GROUP = I_COMPONENT & {
+    name: 'I_CAPTURING_GROUP';
+    groupIndex: number;
+    components: I_COMPONENT[];
+};
+export type I_COMPONENT = I_NODE;
+export type I_MAXIMISING_QUANTIFIER = I_COMPONENT & {
+    name: 'I_MAXIMISING_QUANTIFIER';
+    quantifier: string;
+    component: I_COMPONENT;
+};
+export type I_MINIMISING_QUANTIFIER = I_COMPONENT & {
+    name: 'I_MINIMISING_QUANTIFIER';
+    quantifier: string;
+    component: I_COMPONENT;
+};
+export type I_NAMED_CAPTURING_GROUP = I_COMPONENT & {
+    name: 'I_NAMED_CAPTURING_GROUP';
+    groupIndex: number;
+    groupName: string;
+    components: I_COMPONENT[];
+};
+export type I_NODE = { name: string };
+export type I_NON_CAPTURING_GROUP = I_COMPONENT & {
+    name: 'I_NON_CAPTURING_GROUP';
+    components: I_COMPONENT[];
+};
+export type I_NOOP = I_COMPONENT & { name: 'I_NOOP' };
+export type I_OPTIMISED = I_COMPONENT;
+export type I_PATTERN = I_NODE & {
+    name: 'I_PATTERN';
+    capturingGroups: Array<number | string>;
+    components: I_COMPONENT[];
+};
+export type I_POSSESSIVE_QUANTIFIER = I_COMPONENT & {
+    name: 'I_POSSESSIVE_QUANTIFIER';
+    quantifier: string;
+    component: I_COMPONENT;
+};
+export type I_RAW_REGEX = I_OPTIMISED & {
+    name: 'I_RAW_REGEX';
+    chunks: I_RAW_CHUNK[];
+};
+export type I_RAW_CHUNK =
+    | I_RAW_BACKREFERENCE
+    | I_RAW_CAPTURE
+    | I_RAW_CHARS
+    | I_RAW_GHOST_CAPTURE
+    | I_RAW_NAMED_CAPTURE
+    | I_RAW_NESTED
+    | I_RAW_NON_CAPTURE
+    | I_RAW_NOOP
+    | I_RAW_OPTIMISED;
+export type I_RAW_BACKREFERENCE = {
+    name: 'I_RAW_BACKREFERENCE';
+    id: string;
+};
+export type I_RAW_CAPTURE = {
+    name: 'I_RAW_CAPTURE';
+    id?: string;
+    groupIndex: number;
+    chunks: I_RAW_CHUNK[];
+};
+export type I_RAW_CHARS = {
+    name: 'I_RAW_CHARS';
+    chars: string;
+};
+export type I_RAW_GHOST_CAPTURE = {
+    name: 'I_RAW_GHOST_CAPTURE';
+    id?: string;
+    chunks: I_RAW_CHUNK[];
+};
+export type I_RAW_NAMED_CAPTURE = {
+    name: 'I_RAW_NAMED_CAPTURE';
+    id?: string;
+    groupIndex: number;
+    groupName: string;
+    chunks: I_RAW_CHUNK[];
+};
+export type I_RAW_NESTED = {
+    name: 'I_RAW_NESTED';
+    node: I_RAW_REGEX;
+};
+export type I_RAW_NON_CAPTURE = {
+    name: 'I_RAW_NON_CAPTURE';
+    chunks: I_RAW_CHUNK[];
+};
+export type I_RAW_NOOP = {
+    name: 'I_RAW_NOOP';
+};
+export type I_RAW_OPTIMISED = {
+    name: 'I_RAW_OPTIMISED';
+    chars: string;
+    patternToEmulatedNumberedGroupIndex: {
+        [key: number]: number;
+    };
+};

--- a/src/spec/types/match.ts
+++ b/src/spec/types/match.ts
@@ -1,0 +1,23 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+/**
+ * General match-related types.
+ */
+
+import FragmentMatch from '../../Match/FragmentMatch';
+
+export type Backtracker = (
+    previousMatch: FragmentMatch
+) => FragmentMatch | null;
+
+export type NamedCaptures = { [key: string]: string | null };
+export type NamedCaptureIndices = { [key: string]: [number, number] };
+export type NumberedCaptures = { [key: number]: string | null };
+export type NumberedCaptureIndices = { [key: number]: [number, number] };

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../tsconfig.json",
-  "exclude": [
-    "dist",
-    "node_modules",
-    "test"
-  ]
-}

--- a/test/integration/compiler/astToIntermediate/alternationTest.ts
+++ b/test/integration/compiler/astToIntermediate/alternationTest.ts
@@ -61,10 +61,16 @@ describe('AST-to-IR compiler alternation integration', () => {
             intermediateRepresentation.getTranspilerRepresentation()
         ).to.deep.equal({
             'name': 'I_PATTERN',
+            'capturingGroups': [0],
             'components': [
                 {
                     'name': 'I_RAW_REGEX',
-                    'chars': 'hello',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'hello',
+                        },
+                    ],
                 },
                 {
                     'name': 'I_ALTERNATION',
@@ -74,7 +80,12 @@ describe('AST-to-IR compiler alternation integration', () => {
                             'components': [
                                 {
                                     'name': 'I_RAW_REGEX',
-                                    'chars': 'to',
+                                    'chunks': [
+                                        {
+                                            'name': 'I_RAW_CHARS',
+                                            'chars': 'to',
+                                        },
+                                    ],
                                 },
                             ],
                         },
@@ -83,7 +94,12 @@ describe('AST-to-IR compiler alternation integration', () => {
                             'components': [
                                 {
                                     'name': 'I_RAW_REGEX',
-                                    'chars': 'you',
+                                    'chunks': [
+                                        {
+                                            'name': 'I_RAW_CHARS',
+                                            'chars': 'you',
+                                        },
+                                    ],
                                 },
                             ],
                         },
@@ -91,7 +107,12 @@ describe('AST-to-IR compiler alternation integration', () => {
                 },
                 {
                     'name': 'I_RAW_REGEX',
-                    'chars': 'world',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'world',
+                        },
+                    ],
                 },
             ],
         });

--- a/test/integration/compiler/astToIntermediate/assertion/simpleTest.ts
+++ b/test/integration/compiler/astToIntermediate/assertion/simpleTest.ts
@@ -9,10 +9,10 @@
 
 import emulator from '../../../../../src';
 import { expect } from 'chai';
-import sinon = require('sinon');
 import AstToIntermediateCompiler from '../../../../../src/AstToIntermediateCompiler';
 import Ast from '../../../../../src/Ast';
 import { SinonStubbedInstance } from 'sinon';
+import sinon = require('sinon');
 
 describe('AST-to-IR compiler simple (anchor) assertion integration', () => {
     let compiler: AstToIntermediateCompiler;
@@ -39,18 +39,34 @@ describe('AST-to-IR compiler simple (anchor) assertion integration', () => {
             intermediateRepresentation.getTranspilerRepresentation()
         ).to.deep.equal({
             'name': 'I_PATTERN',
+            'capturingGroups': [0],
             'components': [
                 {
                     'name': 'I_RAW_REGEX',
-                    'chars': 'hello',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'hello',
+                        },
+                    ],
                 },
                 {
                     'name': 'I_RAW_REGEX',
-                    'chars': '^',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': '^',
+                        },
+                    ],
                 },
                 {
                     'name': 'I_RAW_REGEX',
-                    'chars': 'world',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'world',
+                        },
+                    ],
                 },
             ],
         });

--- a/test/integration/compiler/astToIntermediate/characterClassTest.ts
+++ b/test/integration/compiler/astToIntermediate/characterClassTest.ts
@@ -65,18 +65,34 @@ describe('AST-to-IR compiler character class integration', () => {
             intermediateRepresentation.getTranspilerRepresentation()
         ).to.deep.equal({
             'name': 'I_PATTERN',
+            'capturingGroups': [0],
             'components': [
                 {
                     'name': 'I_RAW_REGEX',
-                    'chars': 'hello',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'hello',
+                        },
+                    ],
                 },
                 {
                     'name': 'I_RAW_REGEX',
-                    'chars': '[^]c-dfg-]',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': '[^]c-dfg-]',
+                        },
+                    ],
                 },
                 {
                     'name': 'I_RAW_REGEX',
-                    'chars': 'world',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'world',
+                        },
+                    ],
                 },
             ],
         });

--- a/test/integration/compiler/astToIntermediate/dotTest.ts
+++ b/test/integration/compiler/astToIntermediate/dotTest.ts
@@ -9,10 +9,10 @@
 
 import { expect } from 'chai';
 import emulator from '../../../../src';
-import sinon = require('sinon');
 import AstToIntermediateCompiler from '../../../../src/AstToIntermediateCompiler';
 import Ast from '../../../../src/Ast';
 import { SinonStubbedInstance } from 'sinon';
+import sinon = require('sinon');
 
 describe('AST-to-IR compiler dot (all) integration', () => {
     let compiler: AstToIntermediateCompiler;
@@ -39,18 +39,34 @@ describe('AST-to-IR compiler dot (all) integration', () => {
             intermediateRepresentation.getTranspilerRepresentation()
         ).to.deep.equal({
             'name': 'I_PATTERN',
+            'capturingGroups': [0],
             'components': [
                 {
                     'name': 'I_RAW_REGEX',
-                    'chars': 'hello',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'hello',
+                        },
+                    ],
                 },
                 {
                     'name': 'I_RAW_REGEX',
-                    'chars': '.',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': '.',
+                        },
+                    ],
                 },
                 {
                     'name': 'I_RAW_REGEX',
-                    'chars': 'world',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'world',
+                        },
+                    ],
                 },
             ],
         });

--- a/test/integration/compiler/astToIntermediate/group/capturingGroupTest.ts
+++ b/test/integration/compiler/astToIntermediate/group/capturingGroupTest.ts
@@ -42,23 +42,41 @@ describe('AST-to-IR compiler capturing group integration', () => {
             intermediateRepresentation.getTranspilerRepresentation()
         ).to.deep.equal({
             'name': 'I_PATTERN',
+            // Note that capturing group name "1" is included here.
+            'capturingGroups': [0, 1],
             'components': [
                 {
                     'name': 'I_RAW_REGEX',
-                    'chars': 'hello',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'hello',
+                        },
+                    ],
                 },
                 {
                     'name': 'I_CAPTURING_GROUP',
+                    'groupIndex': 1,
                     'components': [
                         {
                             'name': 'I_RAW_REGEX',
-                            'chars': 'inner',
+                            'chunks': [
+                                {
+                                    'name': 'I_RAW_CHARS',
+                                    'chars': 'inner',
+                                },
+                            ],
                         },
                     ],
                 },
                 {
                     'name': 'I_RAW_REGEX',
-                    'chars': 'world',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'world',
+                        },
+                    ],
                 },
             ],
         });

--- a/test/integration/compiler/astToIntermediate/group/namedCapturingGroupTest.ts
+++ b/test/integration/compiler/astToIntermediate/group/namedCapturingGroupTest.ts
@@ -43,24 +43,42 @@ describe('AST-to-IR compiler named capturing group integration', () => {
             intermediateRepresentation.getTranspilerRepresentation()
         ).to.deep.equal({
             'name': 'I_PATTERN',
+            // Note that both capturing group name "myGroup" and its index 1 are included here.
+            'capturingGroups': [0, 'myGroup', 1],
             'components': [
                 {
                     'name': 'I_RAW_REGEX',
-                    'chars': 'hello',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'hello',
+                        },
+                    ],
                 },
                 {
                     'name': 'I_NAMED_CAPTURING_GROUP',
+                    'groupIndex': 1,
                     'groupName': 'myGroup',
                     'components': [
                         {
                             'name': 'I_RAW_REGEX',
-                            'chars': 'inner',
+                            'chunks': [
+                                {
+                                    'name': 'I_RAW_CHARS',
+                                    'chars': 'inner',
+                                },
+                            ],
                         },
                     ],
                 },
                 {
                     'name': 'I_RAW_REGEX',
-                    'chars': 'world',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'world',
+                        },
+                    ],
                 },
             ],
         });

--- a/test/integration/compiler/astToIntermediate/group/nonCapturingGroupTest.ts
+++ b/test/integration/compiler/astToIntermediate/group/nonCapturingGroupTest.ts
@@ -9,10 +9,10 @@
 
 import { expect } from 'chai';
 import emulator from '../../../../../src';
-import sinon = require('sinon');
 import AstToIntermediateCompiler from '../../../../../src/AstToIntermediateCompiler';
 import Ast from '../../../../../src/Ast';
 import { SinonStubbedInstance } from 'sinon';
+import sinon = require('sinon');
 
 describe('AST-to-IR compiler non-capturing group integration', () => {
     let compiler: AstToIntermediateCompiler;
@@ -42,23 +42,40 @@ describe('AST-to-IR compiler non-capturing group integration', () => {
             intermediateRepresentation.getTranspilerRepresentation()
         ).to.deep.equal({
             'name': 'I_PATTERN',
+            // Note that capturing group index "1" is _not_ included here as this group is non-capturing.
+            'capturingGroups': [0],
             'components': [
                 {
                     'name': 'I_RAW_REGEX',
-                    'chars': 'hello',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'hello',
+                        },
+                    ],
                 },
                 {
                     'name': 'I_NON_CAPTURING_GROUP',
                     'components': [
                         {
                             'name': 'I_RAW_REGEX',
-                            'chars': 'inner',
+                            'chunks': [
+                                {
+                                    'name': 'I_RAW_CHARS',
+                                    'chars': 'inner',
+                                },
+                            ],
                         },
                     ],
                 },
                 {
                     'name': 'I_RAW_REGEX',
-                    'chars': 'world',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'world',
+                        },
+                    ],
                 },
             ],
         });

--- a/test/integration/compiler/astToIntermediate/literalTest.ts
+++ b/test/integration/compiler/astToIntermediate/literalTest.ts
@@ -9,10 +9,10 @@
 
 import { expect } from 'chai';
 import emulator from '../../../../src';
-import sinon = require('sinon');
 import AstToIntermediateCompiler from '../../../../src/AstToIntermediateCompiler';
 import Ast from '../../../../src/Ast';
 import { SinonStubbedInstance } from 'sinon';
+import sinon = require('sinon');
 
 describe('AST-to-IR compiler literal integration', () => {
     let compiler: AstToIntermediateCompiler;
@@ -38,14 +38,25 @@ describe('AST-to-IR compiler literal integration', () => {
             intermediateRepresentation.getTranspilerRepresentation()
         ).to.deep.equal({
             'name': 'I_PATTERN',
+            'capturingGroups': [0],
             'components': [
                 {
                     'name': 'I_RAW_REGEX',
-                    'chars': 'hello',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'hello',
+                        },
+                    ],
                 },
                 {
                     'name': 'I_RAW_REGEX',
-                    'chars': 'world',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'world',
+                        },
+                    ],
                 },
             ],
         });

--- a/test/integration/compiler/astToIntermediate/quantifier/modifier/minimiserTest.ts
+++ b/test/integration/compiler/astToIntermediate/quantifier/modifier/minimiserTest.ts
@@ -9,10 +9,10 @@
 
 import { expect } from 'chai';
 import emulator from '../../../../../../src';
-import sinon = require('sinon');
 import AstToIntermediateCompiler from '../../../../../../src/AstToIntermediateCompiler';
 import Ast from '../../../../../../src/Ast';
 import { SinonStubbedInstance } from 'sinon';
+import sinon = require('sinon');
 
 describe('AST-to-IR compiler quantifier minimiser integration', () => {
     let compiler: AstToIntermediateCompiler;
@@ -47,20 +47,42 @@ describe('AST-to-IR compiler quantifier minimiser integration', () => {
             intermediateRepresentation.getTranspilerRepresentation()
         ).to.deep.equal({
             'name': 'I_PATTERN',
+            'capturingGroups': [0],
             'components': [
                 {
                     'name': 'I_RAW_REGEX',
-                    'chars': 'a',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'a',
+                        },
+                    ],
                 },
                 {
                     'name': 'I_MINIMISING_QUANTIFIER',
                     'quantifier': '+',
-                    'component': { 'name': 'I_RAW_REGEX', 'chars': 'b' },
+                    'component': {
+                        'name': 'I_RAW_REGEX',
+                        'chunks': [
+                            {
+                                'name': 'I_RAW_CHARS',
+                                'chars': 'b',
+                            },
+                        ],
+                    },
                 },
                 {
                     'name': 'I_MINIMISING_QUANTIFIER',
                     'quantifier': '*',
-                    'component': { 'name': 'I_RAW_REGEX', 'chars': 'c' },
+                    'component': {
+                        'name': 'I_RAW_REGEX',
+                        'chunks': [
+                            {
+                                'name': 'I_RAW_CHARS',
+                                'chars': 'c',
+                            },
+                        ],
+                    },
                 },
             ],
         });

--- a/test/integration/compiler/astToIntermediate/quantifier/modifier/possessiveTest.ts
+++ b/test/integration/compiler/astToIntermediate/quantifier/modifier/possessiveTest.ts
@@ -9,10 +9,10 @@
 
 import { expect } from 'chai';
 import emulator from '../../../../../../src';
-import sinon = require('sinon');
 import AstToIntermediateCompiler from '../../../../../../src/AstToIntermediateCompiler';
 import Ast from '../../../../../../src/Ast';
 import { SinonStubbedInstance } from 'sinon';
+import sinon = require('sinon');
 
 describe('AST-to-IR compiler possessive quantifier integration', () => {
     let compiler: AstToIntermediateCompiler;
@@ -47,20 +47,42 @@ describe('AST-to-IR compiler possessive quantifier integration', () => {
             intermediateRepresentation.getTranspilerRepresentation()
         ).to.deep.equal({
             'name': 'I_PATTERN',
+            'capturingGroups': [0],
             'components': [
                 {
                     'name': 'I_RAW_REGEX',
-                    'chars': 'a',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'a',
+                        },
+                    ],
                 },
                 {
                     'name': 'I_POSSESSIVE_QUANTIFIER',
                     'quantifier': '+',
-                    'component': { 'name': 'I_RAW_REGEX', 'chars': 'b' },
+                    'component': {
+                        'name': 'I_RAW_REGEX',
+                        'chunks': [
+                            {
+                                'name': 'I_RAW_CHARS',
+                                'chars': 'b',
+                            },
+                        ],
+                    },
                 },
                 {
                     'name': 'I_POSSESSIVE_QUANTIFIER',
                     'quantifier': '*',
-                    'component': { 'name': 'I_RAW_REGEX', 'chars': 'c' },
+                    'component': {
+                        'name': 'I_RAW_REGEX',
+                        'chunks': [
+                            {
+                                'name': 'I_RAW_CHARS',
+                                'chars': 'c',
+                            },
+                        ],
+                    },
                 },
             ],
         });

--- a/test/integration/compiler/astToIntermediate/quantifier/oneOrMoreTest.ts
+++ b/test/integration/compiler/astToIntermediate/quantifier/oneOrMoreTest.ts
@@ -9,10 +9,10 @@
 
 import { expect } from 'chai';
 import emulator from '../../../../../src';
-import sinon = require('sinon');
 import AstToIntermediateCompiler from '../../../../../src/AstToIntermediateCompiler';
 import Ast from '../../../../../src/Ast';
 import { SinonStubbedInstance } from 'sinon';
+import sinon = require('sinon');
 
 describe('AST-to-IR compiler one-or-more quantifier integration', () => {
     let compiler: AstToIntermediateCompiler;
@@ -47,20 +47,42 @@ describe('AST-to-IR compiler one-or-more quantifier integration', () => {
             intermediateRepresentation.getTranspilerRepresentation()
         ).to.deep.equal({
             'name': 'I_PATTERN',
+            'capturingGroups': [0],
             'components': [
                 {
                     'name': 'I_RAW_REGEX',
-                    'chars': 'a',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'a',
+                        },
+                    ],
                 },
                 {
                     'name': 'I_MAXIMISING_QUANTIFIER',
                     'quantifier': '+',
-                    'component': { 'name': 'I_RAW_REGEX', 'chars': 'b' },
+                    'component': {
+                        'name': 'I_RAW_REGEX',
+                        'chunks': [
+                            {
+                                'name': 'I_RAW_CHARS',
+                                'chars': 'b',
+                            },
+                        ],
+                    },
                 },
                 {
                     'name': 'I_MAXIMISING_QUANTIFIER',
                     'quantifier': '+',
-                    'component': { 'name': 'I_RAW_REGEX', 'chars': 'c' },
+                    'component': {
+                        'name': 'I_RAW_REGEX',
+                        'chunks': [
+                            {
+                                'name': 'I_RAW_CHARS',
+                                'chars': 'c',
+                            },
+                        ],
+                    },
                 },
             ],
         });

--- a/test/integration/compiler/astToIntermediate/quantifier/optionalTest.ts
+++ b/test/integration/compiler/astToIntermediate/quantifier/optionalTest.ts
@@ -9,10 +9,10 @@
 
 import { expect } from 'chai';
 import emulator from '../../../../../src';
-import sinon = require('sinon');
 import AstToIntermediateCompiler from '../../../../../src/AstToIntermediateCompiler';
 import Ast from '../../../../../src/Ast';
 import { SinonStubbedInstance } from 'sinon';
+import sinon = require('sinon');
 
 describe('AST-to-IR compiler optional quantifier integration', () => {
     let compiler: AstToIntermediateCompiler;
@@ -47,20 +47,42 @@ describe('AST-to-IR compiler optional quantifier integration', () => {
             intermediateRepresentation.getTranspilerRepresentation()
         ).to.deep.equal({
             'name': 'I_PATTERN',
+            'capturingGroups': [0],
             'components': [
                 {
                     'name': 'I_RAW_REGEX',
-                    'chars': 'a',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'a',
+                        },
+                    ],
                 },
                 {
                     'name': 'I_MAXIMISING_QUANTIFIER',
                     'quantifier': '?',
-                    'component': { 'name': 'I_RAW_REGEX', 'chars': 'b' },
+                    'component': {
+                        'name': 'I_RAW_REGEX',
+                        'chunks': [
+                            {
+                                'name': 'I_RAW_CHARS',
+                                'chars': 'b',
+                            },
+                        ],
+                    },
                 },
                 {
                     'name': 'I_MAXIMISING_QUANTIFIER',
                     'quantifier': '?',
-                    'component': { 'name': 'I_RAW_REGEX', 'chars': 'c' },
+                    'component': {
+                        'name': 'I_RAW_REGEX',
+                        'chunks': [
+                            {
+                                'name': 'I_RAW_CHARS',
+                                'chars': 'c',
+                            },
+                        ],
+                    },
                 },
             ],
         });

--- a/test/integration/compiler/astToIntermediate/quantifier/zeroOrMoreTest.ts
+++ b/test/integration/compiler/astToIntermediate/quantifier/zeroOrMoreTest.ts
@@ -9,10 +9,10 @@
 
 import { expect } from 'chai';
 import emulator from '../../../../../src';
-import sinon = require('sinon');
 import AstToIntermediateCompiler from '../../../../../src/AstToIntermediateCompiler';
 import Ast from '../../../../../src/Ast';
 import { SinonStubbedInstance } from 'sinon';
+import sinon = require('sinon');
 
 describe('AST-to-IR compiler zero-or-more quantifier integration', () => {
     let compiler: AstToIntermediateCompiler;
@@ -47,20 +47,42 @@ describe('AST-to-IR compiler zero-or-more quantifier integration', () => {
             intermediateRepresentation.getTranspilerRepresentation()
         ).to.deep.equal({
             'name': 'I_PATTERN',
+            'capturingGroups': [0],
             'components': [
                 {
                     'name': 'I_RAW_REGEX',
-                    'chars': 'a',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'a',
+                        },
+                    ],
                 },
                 {
                     'name': 'I_MAXIMISING_QUANTIFIER',
                     'quantifier': '*',
-                    'component': { 'name': 'I_RAW_REGEX', 'chars': 'b' },
+                    'component': {
+                        'name': 'I_RAW_REGEX',
+                        'chunks': [
+                            {
+                                'name': 'I_RAW_CHARS',
+                                'chars': 'b',
+                            },
+                        ],
+                    },
                 },
                 {
                     'name': 'I_MAXIMISING_QUANTIFIER',
                     'quantifier': '*',
-                    'component': { 'name': 'I_RAW_REGEX', 'chars': 'c' },
+                    'component': {
+                        'name': 'I_RAW_REGEX',
+                        'chunks': [
+                            {
+                                'name': 'I_RAW_CHARS',
+                                'chars': 'c',
+                            },
+                        ],
+                    },
                 },
             ],
         });

--- a/test/integration/compiler/intermediateOptimiser/accelerateRawPass/alternationTest.ts
+++ b/test/integration/compiler/intermediateOptimiser/accelerateRawPass/alternationTest.ts
@@ -1,0 +1,152 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import { expect } from 'chai';
+import accelerateRawPassSpec from '../../../../../src/spec/intermediateOptimiser/accelerateRawPass';
+import emulator from '../../../../../src';
+import { SinonStubbedInstance } from 'sinon';
+import IntermediateOptimiser from '../../../../../src/IntermediateOptimiser';
+import IntermediateRepresentation from '../../../../../src/IntermediateRepresentation';
+import sinon = require('sinon');
+
+describe('IR optimiser accelerateRawPass compiler alternation integration', () => {
+    let optimiser: IntermediateOptimiser;
+
+    beforeEach(() => {
+        optimiser = emulator.createPartialIntermediateOptimiser([
+            accelerateRawPassSpec,
+        ]);
+    });
+
+    it('should be able to optimise an IR with one alternation', () => {
+        const ir = sinon.createStubInstance(
+            IntermediateRepresentation
+        ) as SinonStubbedInstance<IntermediateRepresentation> &
+            IntermediateRepresentation;
+        ir.getTranspilerRepresentation.returns({
+            'name': 'I_PATTERN',
+            'capturingGroups': [0],
+            'components': [
+                {
+                    'name': 'I_RAW_REGEX',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'hello',
+                        },
+                    ],
+                },
+                {
+                    'name': 'I_NON_CAPTURING_GROUP',
+                    'components': [
+                        {
+                            'name': 'I_ALTERNATION',
+                            'alternatives': [
+                                {
+                                    'name': 'I_ALTERNATIVE',
+                                    'components': [
+                                        {
+                                            'name': 'I_RAW_REGEX',
+                                            'chunks': [
+                                                {
+                                                    'name': 'I_RAW_CHARS',
+                                                    'chars': 'to',
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                                {
+                                    'name': 'I_ALTERNATIVE',
+                                    'components': [
+                                        {
+                                            'name': 'I_RAW_REGEX',
+                                            'chunks': [
+                                                {
+                                                    'name': 'I_RAW_CHARS',
+                                                    'chars': 'you',
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    'name': 'I_RAW_REGEX',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'world',
+                        },
+                    ],
+                },
+            ],
+        });
+
+        const intermediateRepresentation = optimiser.optimise(ir);
+
+        expect(
+            intermediateRepresentation.getTranspilerRepresentation()
+        ).to.deep.equal({
+            'name': 'I_PATTERN',
+            'capturingGroups': [0],
+            'components': [
+                {
+                    'name': 'I_RAW_REGEX',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'hello',
+                        },
+                        {
+                            'name': 'I_RAW_NON_CAPTURE',
+                            'chunks': [
+                                {
+                                    'name': 'I_RAW_NESTED',
+                                    'node': {
+                                        'name': 'I_RAW_REGEX',
+                                        'chunks': [
+                                            {
+                                                'name': 'I_RAW_NESTED',
+                                                'node': {
+                                                    'name': 'I_RAW_REGEX',
+                                                    'chunks': [
+                                                        {
+                                                            'name': 'I_RAW_CHARS',
+                                                            'chars': 'to',
+                                                        },
+                                                        {
+                                                            'name': 'I_RAW_CHARS',
+                                                            'chars': '|',
+                                                        },
+                                                        {
+                                                            'name': 'I_RAW_CHARS',
+                                                            'chars': 'you',
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                        ],
+                                    },
+                                },
+                            ],
+                        },
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'world',
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+});

--- a/test/integration/compiler/intermediateOptimiser/accelerateRawPass/group/capturingGroupTest.ts
+++ b/test/integration/compiler/intermediateOptimiser/accelerateRawPass/group/capturingGroupTest.ts
@@ -1,0 +1,116 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import { expect } from 'chai';
+import accelerateRawPassSpec from '../../../../../../src/spec/intermediateOptimiser/accelerateRawPass';
+import emulator from '../../../../../../src';
+import { SinonStubbedInstance } from 'sinon';
+import IntermediateOptimiser from '../../../../../../src/IntermediateOptimiser';
+import IntermediateRepresentation from '../../../../../../src/IntermediateRepresentation';
+import sinon = require('sinon');
+
+describe('IR optimiser accelerateRawPass compiler capturing group integration', () => {
+    let optimiser: IntermediateOptimiser;
+
+    beforeEach(() => {
+        optimiser = emulator.createPartialIntermediateOptimiser([
+            accelerateRawPassSpec,
+        ]);
+    });
+
+    it('should be able to optimise an IR with a capturing group', () => {
+        const ir = sinon.createStubInstance(
+            IntermediateRepresentation
+        ) as SinonStubbedInstance<IntermediateRepresentation> &
+            IntermediateRepresentation;
+        ir.getTranspilerRepresentation.returns({
+            'name': 'I_PATTERN',
+            // Note that capturing group name "1" is included here.
+            'capturingGroups': [0, 1],
+            'components': [
+                {
+                    'name': 'I_RAW_REGEX',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'hello',
+                        },
+                    ],
+                },
+                {
+                    'name': 'I_CAPTURING_GROUP',
+                    'groupIndex': 1,
+                    'components': [
+                        {
+                            'name': 'I_RAW_REGEX',
+                            'chunks': [
+                                {
+                                    'name': 'I_RAW_CHARS',
+                                    'chars': 'inner',
+                                },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    'name': 'I_RAW_REGEX',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'world',
+                        },
+                    ],
+                },
+            ],
+        });
+
+        const intermediateRepresentation = optimiser.optimise(ir);
+
+        expect(
+            intermediateRepresentation.getTranspilerRepresentation()
+        ).to.deep.equal({
+            'name': 'I_PATTERN',
+            // Note that capturing group name "1" is included here.
+            'capturingGroups': [0, 1],
+            'components': [
+                {
+                    'name': 'I_RAW_REGEX',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'hello',
+                        },
+                        {
+                            'name': 'I_RAW_CAPTURE',
+                            'groupIndex': 1,
+                            'chunks': [
+                                {
+                                    'name': 'I_RAW_NESTED',
+                                    'node': {
+                                        'name': 'I_RAW_REGEX',
+                                        'chunks': [
+                                            {
+                                                'name': 'I_RAW_CHARS',
+                                                'chars': 'inner',
+                                            },
+                                        ],
+                                    },
+                                },
+                            ],
+                        },
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'world',
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+});

--- a/test/integration/compiler/intermediateOptimiser/accelerateRawPass/group/namedCapturingGroupTest.ts
+++ b/test/integration/compiler/intermediateOptimiser/accelerateRawPass/group/namedCapturingGroupTest.ts
@@ -1,0 +1,118 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import { expect } from 'chai';
+import accelerateRawPassSpec from '../../../../../../src/spec/intermediateOptimiser/accelerateRawPass';
+import emulator from '../../../../../../src';
+import { SinonStubbedInstance } from 'sinon';
+import IntermediateOptimiser from '../../../../../../src/IntermediateOptimiser';
+import IntermediateRepresentation from '../../../../../../src/IntermediateRepresentation';
+import sinon = require('sinon');
+
+describe('IR optimiser accelerateRawPass compiler named capturing group integration', () => {
+    let optimiser: IntermediateOptimiser;
+
+    beforeEach(() => {
+        optimiser = emulator.createPartialIntermediateOptimiser([
+            accelerateRawPassSpec,
+        ]);
+    });
+
+    it('should be able to optimise an IR with a named capturing group', () => {
+        const ir = sinon.createStubInstance(
+            IntermediateRepresentation
+        ) as SinonStubbedInstance<IntermediateRepresentation> &
+            IntermediateRepresentation;
+        ir.getTranspilerRepresentation.returns({
+            'name': 'I_PATTERN',
+            // Note that both capturing group name "myGroup" and its index 1 are included here.
+            'capturingGroups': [0, 'myGroup', 1],
+            'components': [
+                {
+                    'name': 'I_RAW_REGEX',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'hello',
+                        },
+                    ],
+                },
+                {
+                    'name': 'I_NAMED_CAPTURING_GROUP',
+                    'groupIndex': 1,
+                    'groupName': 'myGroup',
+                    'components': [
+                        {
+                            'name': 'I_RAW_REGEX',
+                            'chunks': [
+                                {
+                                    'name': 'I_RAW_CHARS',
+                                    'chars': 'inner',
+                                },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    'name': 'I_RAW_REGEX',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'world',
+                        },
+                    ],
+                },
+            ],
+        });
+
+        const intermediateRepresentation = optimiser.optimise(ir);
+
+        expect(
+            intermediateRepresentation.getTranspilerRepresentation()
+        ).to.deep.equal({
+            'name': 'I_PATTERN',
+            // Note that both capturing group name "myGroup" and its index 1 are included here.
+            'capturingGroups': [0, 'myGroup', 1],
+            'components': [
+                {
+                    'name': 'I_RAW_REGEX',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'hello',
+                        },
+                        {
+                            'name': 'I_RAW_NAMED_CAPTURE',
+                            'groupIndex': 1,
+                            'groupName': 'myGroup',
+                            'chunks': [
+                                {
+                                    'name': 'I_RAW_NESTED',
+                                    'node': {
+                                        'name': 'I_RAW_REGEX',
+                                        'chunks': [
+                                            {
+                                                'name': 'I_RAW_CHARS',
+                                                'chars': 'inner',
+                                            },
+                                        ],
+                                    },
+                                },
+                            ],
+                        },
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'world',
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+});

--- a/test/integration/compiler/intermediateOptimiser/accelerateRawPass/group/nonCapturingGroupTest.ts
+++ b/test/integration/compiler/intermediateOptimiser/accelerateRawPass/group/nonCapturingGroupTest.ts
@@ -1,0 +1,115 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import { expect } from 'chai';
+import accelerateRawPassSpec from '../../../../../../src/spec/intermediateOptimiser/accelerateRawPass';
+import emulator from '../../../../../../src';
+import { SinonStubbedInstance } from 'sinon';
+import IntermediateOptimiser from '../../../../../../src/IntermediateOptimiser';
+import IntermediateRepresentation from '../../../../../../src/IntermediateRepresentation';
+import sinon = require('sinon');
+
+describe('IR optimiser accelerateRawPass compiler non-capturing group integration', () => {
+    let optimiser: IntermediateOptimiser;
+
+    beforeEach(() => {
+        optimiser = emulator.createPartialIntermediateOptimiser([
+            accelerateRawPassSpec,
+        ]);
+    });
+
+    it('should be able to optimise an IR with a non-capturing group', () => {
+        const ir = sinon.createStubInstance(
+            IntermediateRepresentation
+        ) as SinonStubbedInstance<IntermediateRepresentation> &
+            IntermediateRepresentation;
+        ir.getTranspilerRepresentation.returns({
+            'name': 'I_PATTERN',
+            // Note that capturing group index "1" is _not_ included here as this group is non-capturing.
+            'capturingGroups': [0],
+            'components': [
+                {
+                    'name': 'I_RAW_REGEX',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'hello',
+                        },
+                    ],
+                },
+                {
+                    'name': 'I_NON_CAPTURING_GROUP',
+                    'groupIndex': 1,
+                    'components': [
+                        {
+                            'name': 'I_RAW_REGEX',
+                            'chunks': [
+                                {
+                                    'name': 'I_RAW_CHARS',
+                                    'chars': 'inner',
+                                },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    'name': 'I_RAW_REGEX',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'world',
+                        },
+                    ],
+                },
+            ],
+        });
+
+        const intermediateRepresentation = optimiser.optimise(ir);
+
+        expect(
+            intermediateRepresentation.getTranspilerRepresentation()
+        ).to.deep.equal({
+            'name': 'I_PATTERN',
+            // Note that capturing group index "1" is _not_ included here as this group is non-capturing.
+            'capturingGroups': [0],
+            'components': [
+                {
+                    'name': 'I_RAW_REGEX',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'hello',
+                        },
+                        {
+                            'name': 'I_RAW_NON_CAPTURE',
+                            'chunks': [
+                                {
+                                    'name': 'I_RAW_NESTED',
+                                    'node': {
+                                        'name': 'I_RAW_REGEX',
+                                        'chunks': [
+                                            {
+                                                'name': 'I_RAW_CHARS',
+                                                'chars': 'inner',
+                                            },
+                                        ],
+                                    },
+                                },
+                            ],
+                        },
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'world',
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+});

--- a/test/integration/compiler/intermediateOptimiser/accelerateRawPass/quantifier/maximisingTest.ts
+++ b/test/integration/compiler/intermediateOptimiser/accelerateRawPass/quantifier/maximisingTest.ts
@@ -1,0 +1,126 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import { expect } from 'chai';
+import accelerateRawPassSpec from '../../../../../../src/spec/intermediateOptimiser/accelerateRawPass';
+import emulator from '../../../../../../src';
+import { SinonStubbedInstance } from 'sinon';
+import IntermediateOptimiser from '../../../../../../src/IntermediateOptimiser';
+import IntermediateRepresentation from '../../../../../../src/IntermediateRepresentation';
+import sinon = require('sinon');
+
+describe('IR optimiser accelerateRawPass compiler maximising quantifier integration', () => {
+    let optimiser: IntermediateOptimiser;
+
+    beforeEach(() => {
+        optimiser = emulator.createPartialIntermediateOptimiser([
+            accelerateRawPassSpec,
+        ]);
+    });
+
+    it('should be able to optimise an IR with two maximising quantifiers', () => {
+        const ir = sinon.createStubInstance(
+            IntermediateRepresentation
+        ) as SinonStubbedInstance<IntermediateRepresentation> &
+            IntermediateRepresentation;
+        ir.getTranspilerRepresentation.returns({
+            'name': 'I_PATTERN',
+            'capturingGroups': [0],
+            'components': [
+                {
+                    'name': 'I_RAW_REGEX',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'a',
+                        },
+                    ],
+                },
+                {
+                    'name': 'I_MAXIMISING_QUANTIFIER',
+                    'quantifier': '*',
+                    'component': {
+                        'name': 'I_RAW_REGEX',
+                        'chunks': [
+                            {
+                                'name': 'I_RAW_CHARS',
+                                'chars': 'b',
+                            },
+                        ],
+                    },
+                },
+                {
+                    'name': 'I_MAXIMISING_QUANTIFIER',
+                    'quantifier': '+',
+                    'component': {
+                        'name': 'I_RAW_REGEX',
+                        'chunks': [
+                            {
+                                'name': 'I_RAW_CHARS',
+                                'chars': 'c',
+                            },
+                        ],
+                    },
+                },
+            ],
+        });
+
+        const intermediateRepresentation = optimiser.optimise(ir);
+
+        expect(
+            intermediateRepresentation.getTranspilerRepresentation()
+        ).to.deep.equal({
+            'name': 'I_PATTERN',
+            'capturingGroups': [0],
+            'components': [
+                {
+                    'name': 'I_RAW_REGEX',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'a',
+                        },
+                        {
+                            'name': 'I_RAW_NESTED',
+                            'node': {
+                                'name': 'I_RAW_REGEX',
+                                'chunks': [
+                                    {
+                                        'name': 'I_RAW_CHARS',
+                                        'chars': 'b',
+                                    },
+                                ],
+                            },
+                        },
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': '*',
+                        },
+                        {
+                            'name': 'I_RAW_NESTED',
+                            'node': {
+                                'name': 'I_RAW_REGEX',
+                                'chunks': [
+                                    {
+                                        'name': 'I_RAW_CHARS',
+                                        'chars': 'c',
+                                    },
+                                ],
+                            },
+                        },
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': '+',
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+});

--- a/test/integration/compiler/intermediateOptimiser/accelerateRawPass/quantifier/modifier/minimiserTest.ts
+++ b/test/integration/compiler/intermediateOptimiser/accelerateRawPass/quantifier/modifier/minimiserTest.ts
@@ -1,0 +1,126 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import { expect } from 'chai';
+import accelerateRawPassSpec from '../../../../../../../src/spec/intermediateOptimiser/accelerateRawPass';
+import emulator from '../../../../../../../src';
+import { SinonStubbedInstance } from 'sinon';
+import IntermediateOptimiser from '../../../../../../../src/IntermediateOptimiser';
+import IntermediateRepresentation from '../../../../../../../src/IntermediateRepresentation';
+import sinon = require('sinon');
+
+describe('IR optimiser accelerateRawPass compiler minimising quantifier integration', () => {
+    let optimiser: IntermediateOptimiser;
+
+    beforeEach(() => {
+        optimiser = emulator.createPartialIntermediateOptimiser([
+            accelerateRawPassSpec,
+        ]);
+    });
+
+    it('should be able to optimise an IR with two minimising quantifiers', () => {
+        const ir = sinon.createStubInstance(
+            IntermediateRepresentation
+        ) as SinonStubbedInstance<IntermediateRepresentation> &
+            IntermediateRepresentation;
+        ir.getTranspilerRepresentation.returns({
+            'name': 'I_PATTERN',
+            'capturingGroups': [0],
+            'components': [
+                {
+                    'name': 'I_RAW_REGEX',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'a',
+                        },
+                    ],
+                },
+                {
+                    'name': 'I_MINIMISING_QUANTIFIER',
+                    'quantifier': '*',
+                    'component': {
+                        'name': 'I_RAW_REGEX',
+                        'chunks': [
+                            {
+                                'name': 'I_RAW_CHARS',
+                                'chars': 'b',
+                            },
+                        ],
+                    },
+                },
+                {
+                    'name': 'I_MINIMISING_QUANTIFIER',
+                    'quantifier': '+',
+                    'component': {
+                        'name': 'I_RAW_REGEX',
+                        'chunks': [
+                            {
+                                'name': 'I_RAW_CHARS',
+                                'chars': 'c',
+                            },
+                        ],
+                    },
+                },
+            ],
+        });
+
+        const intermediateRepresentation = optimiser.optimise(ir);
+
+        expect(
+            intermediateRepresentation.getTranspilerRepresentation()
+        ).to.deep.equal({
+            'name': 'I_PATTERN',
+            'capturingGroups': [0],
+            'components': [
+                {
+                    'name': 'I_RAW_REGEX',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'a',
+                        },
+                        {
+                            'name': 'I_RAW_NESTED',
+                            'node': {
+                                'name': 'I_RAW_REGEX',
+                                'chunks': [
+                                    {
+                                        'name': 'I_RAW_CHARS',
+                                        'chars': 'b',
+                                    },
+                                ],
+                            },
+                        },
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': '*?',
+                        },
+                        {
+                            'name': 'I_RAW_NESTED',
+                            'node': {
+                                'name': 'I_RAW_REGEX',
+                                'chunks': [
+                                    {
+                                        'name': 'I_RAW_CHARS',
+                                        'chars': 'c',
+                                    },
+                                ],
+                            },
+                        },
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': '+?',
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+});

--- a/test/integration/compiler/intermediateOptimiser/accelerateRawPass/quantifier/modifier/possessiveTest.ts
+++ b/test/integration/compiler/intermediateOptimiser/accelerateRawPass/quantifier/modifier/possessiveTest.ts
@@ -1,0 +1,162 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import { expect } from 'chai';
+import accelerateRawPassSpec from '../../../../../../../src/spec/intermediateOptimiser/accelerateRawPass';
+import emulator from '../../../../../../../src';
+import { SinonStubbedInstance } from 'sinon';
+import IntermediateOptimiser from '../../../../../../../src/IntermediateOptimiser';
+import IntermediateRepresentation from '../../../../../../../src/IntermediateRepresentation';
+import sinon = require('sinon');
+
+describe('IR optimiser accelerateRawPass compiler possessive quantifier integration', () => {
+    let optimiser: IntermediateOptimiser;
+
+    beforeEach(() => {
+        optimiser = emulator.createPartialIntermediateOptimiser([
+            accelerateRawPassSpec,
+        ]);
+    });
+
+    it('should be able to optimise an IR with two possessive quantifiers', () => {
+        const ir = sinon.createStubInstance(
+            IntermediateRepresentation
+        ) as SinonStubbedInstance<IntermediateRepresentation> &
+            IntermediateRepresentation;
+        ir.getTranspilerRepresentation.returns({
+            'name': 'I_PATTERN',
+            'capturingGroups': [0],
+            'components': [
+                {
+                    'name': 'I_RAW_REGEX',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'a',
+                        },
+                    ],
+                },
+                {
+                    'name': 'I_POSSESSIVE_QUANTIFIER',
+                    'quantifier': '*',
+                    'component': {
+                        'name': 'I_RAW_REGEX',
+                        'chunks': [
+                            {
+                                'name': 'I_RAW_CHARS',
+                                'chars': 'b',
+                            },
+                        ],
+                    },
+                },
+                {
+                    'name': 'I_POSSESSIVE_QUANTIFIER',
+                    'quantifier': '+',
+                    'component': {
+                        'name': 'I_RAW_REGEX',
+                        'chunks': [
+                            {
+                                'name': 'I_RAW_CHARS',
+                                'chars': 'c',
+                            },
+                        ],
+                    },
+                },
+            ],
+        });
+
+        const intermediateRepresentation = optimiser.optimise(ir);
+
+        expect(
+            intermediateRepresentation.getTranspilerRepresentation()
+        ).to.deep.equal({
+            'name': 'I_PATTERN',
+            'capturingGroups': [0],
+            'components': [
+                {
+                    'name': 'I_RAW_REGEX',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'a',
+                        },
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': '(?=',
+                        },
+                        {
+                            'name': 'I_RAW_GHOST_CAPTURE',
+                            'id': 'atomic',
+                            'chunks': [
+                                {
+                                    'name': 'I_RAW_NESTED',
+                                    'node': {
+                                        'name': 'I_RAW_REGEX',
+                                        'chunks': [
+                                            {
+                                                'name': 'I_RAW_CHARS',
+                                                'chars': 'b',
+                                            },
+                                        ],
+                                    },
+                                },
+                                {
+                                    'name': 'I_RAW_CHARS',
+                                    'chars': '*',
+                                },
+                            ],
+                        },
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': ')',
+                        },
+                        {
+                            'name': 'I_RAW_BACKREFERENCE',
+                            'id': 'atomic',
+                        },
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': '(?=',
+                        },
+                        {
+                            'name': 'I_RAW_GHOST_CAPTURE',
+                            'id': 'atomic',
+                            'chunks': [
+                                {
+                                    'name': 'I_RAW_NESTED',
+                                    'node': {
+                                        'name': 'I_RAW_REGEX',
+                                        'chunks': [
+                                            {
+                                                'name': 'I_RAW_CHARS',
+                                                'chars': 'c',
+                                            },
+                                        ],
+                                    },
+                                },
+                                {
+                                    'name': 'I_RAW_CHARS',
+                                    'chars': '+',
+                                },
+                            ],
+                        },
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': ')',
+                        },
+                        {
+                            'name': 'I_RAW_BACKREFERENCE',
+                            'id': 'atomic',
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+});

--- a/test/integration/compiler/intermediateOptimiser/accelerateRawPass/rawRegexTest.ts
+++ b/test/integration/compiler/intermediateOptimiser/accelerateRawPass/rawRegexTest.ts
@@ -1,0 +1,94 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import { expect } from 'chai';
+import accelerateRawPassSpec from '../../../../../src/spec/intermediateOptimiser/accelerateRawPass';
+import emulator from '../../../../../src';
+import { SinonStubbedInstance } from 'sinon';
+import IntermediateOptimiser from '../../../../../src/IntermediateOptimiser';
+import IntermediateRepresentation from '../../../../../src/IntermediateRepresentation';
+import sinon = require('sinon');
+
+describe('IR optimiser accelerateRawPass compiler raw regex integration', () => {
+    let optimiser: IntermediateOptimiser;
+
+    beforeEach(() => {
+        optimiser = emulator.createPartialIntermediateOptimiser([
+            accelerateRawPassSpec,
+        ]);
+    });
+
+    it('should be able to optimise an IR with a raw regex character class', () => {
+        const ir = sinon.createStubInstance(
+            IntermediateRepresentation
+        ) as SinonStubbedInstance<IntermediateRepresentation> &
+            IntermediateRepresentation;
+        ir.getTranspilerRepresentation.returns({
+            'name': 'I_PATTERN',
+            'capturingGroups': [0],
+            'components': [
+                {
+                    'name': 'I_RAW_REGEX',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'hello',
+                        },
+                    ],
+                },
+                {
+                    'name': 'I_RAW_REGEX',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': '[^]c-dfg-]',
+                        },
+                    ],
+                },
+                {
+                    'name': 'I_RAW_REGEX',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'world',
+                        },
+                    ],
+                },
+            ],
+        });
+
+        const intermediateRepresentation = optimiser.optimise(ir);
+
+        expect(
+            intermediateRepresentation.getTranspilerRepresentation()
+        ).to.deep.equal({
+            'name': 'I_PATTERN',
+            'capturingGroups': [0],
+            'components': [
+                {
+                    'name': 'I_RAW_REGEX',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'hello',
+                        },
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': '[^]c-dfg-]',
+                        },
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'world',
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+});

--- a/test/integration/compiler/intermediateOptimiser/compileRawPass/allNodesTest.ts
+++ b/test/integration/compiler/intermediateOptimiser/compileRawPass/allNodesTest.ts
@@ -1,0 +1,288 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import { expect } from 'chai';
+import compileRawPassSpec from '../../../../../src/spec/intermediateOptimiser/compileRawPass';
+import emulator from '../../../../../src';
+import { SinonStubbedInstance } from 'sinon';
+import IntermediateOptimiser from '../../../../../src/IntermediateOptimiser';
+import IntermediateRepresentation from '../../../../../src/IntermediateRepresentation';
+import sinon = require('sinon');
+
+describe('IR optimiser compileRawPass compiler all nodes integration', () => {
+    let optimiser: IntermediateOptimiser;
+
+    beforeEach(() => {
+        optimiser = emulator.createPartialIntermediateOptimiser([
+            compileRawPassSpec,
+        ]);
+    });
+
+    it('should be able to optimise an IR with all raw nodes', () => {
+        const ir = sinon.createStubInstance(
+            IntermediateRepresentation
+        ) as SinonStubbedInstance<IntermediateRepresentation> &
+            IntermediateRepresentation;
+        ir.getTranspilerRepresentation.returns({
+            'name': 'I_PATTERN',
+            'capturingGroups': [0, 1, 'myGroup', 3],
+            'components': [
+                {
+                    'name': 'I_RAW_REGEX',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'before-capture-one',
+                        },
+                        {
+                            'name': 'I_RAW_CAPTURE',
+                            'id': 'myFirstRef',
+                            'groupIndex': 2,
+                            'chunks': [
+                                {
+                                    'name': 'I_RAW_CHARS',
+                                    'chars': 'in-capture-one',
+                                },
+                            ],
+                        },
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'after-capture-one',
+                        },
+                        {
+                            'name': 'I_RAW_BACKREFERENCE',
+                            'id': 'myFirstRef',
+                        },
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'before-capture-two',
+                        },
+                        {
+                            'name': 'I_RAW_CAPTURE',
+                            'id': 'mySecondRef',
+                            'groupIndex': 1,
+                            'chunks': [
+                                {
+                                    'name': 'I_RAW_CHARS',
+                                    'chars': 'in-capture-two',
+                                },
+                            ],
+                        },
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'after-capture-two',
+                        },
+                        {
+                            'name': 'I_RAW_BACKREFERENCE',
+                            'id': 'mySecondRef',
+                        },
+                    ],
+                },
+                {
+                    'name': 'I_RAW_REGEX',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'before-ghost',
+                        },
+                        {
+                            'name': 'I_RAW_GHOST_CAPTURE',
+                            'id': 'myThirdRef',
+                            'chunks': [
+                                {
+                                    'name': 'I_RAW_CHARS',
+                                    'chars': 'in-ghost',
+                                },
+                            ],
+                        },
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'after-ghost',
+                        },
+                        {
+                            'name': 'I_RAW_BACKREFERENCE',
+                            'id': 'myThirdRef',
+                        },
+                    ],
+                },
+                {
+                    'name': 'I_RAW_REGEX',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'before-named',
+                        },
+                        {
+                            'name': 'I_RAW_NAMED_CAPTURE',
+                            'id': 'myThirdRef',
+                            'groupIndex': 3,
+                            'groupName': 'myGroup',
+                            'chunks': [
+                                {
+                                    'name': 'I_RAW_CHARS',
+                                    'chars': 'in-named',
+                                },
+                            ],
+                        },
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'after-named',
+                        },
+                        {
+                            'name': 'I_RAW_BACKREFERENCE',
+                            'id': 'myThirdRef',
+                        },
+                    ],
+                },
+                {
+                    'name': 'I_RAW_REGEX',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'before-nested',
+                        },
+                        {
+                            'name': 'I_RAW_NESTED',
+                            'node': {
+                                'name': 'I_RAW_REGEX',
+                                'chunks': [
+                                    {
+                                        'name': 'I_RAW_CHARS',
+                                        'chars': 'in-nested',
+                                    },
+                                ],
+                            },
+                        },
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'after-nested',
+                        },
+                    ],
+                },
+                {
+                    'name': 'I_RAW_REGEX',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'before-non-capture',
+                        },
+                        {
+                            'name': 'I_RAW_NON_CAPTURE',
+                            'chunks': [
+                                {
+                                    'name': 'I_RAW_CHARS',
+                                    'chars': 'in-non-capture',
+                                },
+                            ],
+                        },
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'after-non-capture',
+                        },
+                    ],
+                },
+                {
+                    'name': 'I_RAW_REGEX',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'before-noop',
+                        },
+                        {
+                            'name': 'I_RAW_NOOP',
+                        },
+                        {
+                            'name': 'I_RAW_CHARS',
+                            'chars': 'after-noop',
+                        },
+                    ],
+                },
+            ],
+        });
+
+        const intermediateRepresentation = optimiser.optimise(ir);
+
+        expect(
+            intermediateRepresentation.getTranspilerRepresentation()
+        ).to.deep.equal({
+            'name': 'I_PATTERN',
+            'capturingGroups': [0, 1, 'myGroup', 3],
+            'components': [
+                {
+                    'name': 'I_RAW_REGEX',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_OPTIMISED',
+                            'chars':
+                                'before-capture-one(in-capture-one)after-capture-one\\1before-capture-two(in-capture-two)after-capture-two\\2',
+                            'patternToEmulatedNumberedGroupIndex': {
+                                '2': 1,
+                                '1': 2,
+                            },
+                        },
+                    ],
+                },
+                {
+                    'name': 'I_RAW_REGEX',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_OPTIMISED',
+                            'chars': 'before-ghost(in-ghost)after-ghost\\1',
+                            'patternToEmulatedNumberedGroupIndex': {},
+                        },
+                    ],
+                },
+                {
+                    'name': 'I_RAW_REGEX',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_OPTIMISED',
+                            'chars':
+                                'before-named(?<myGroup>in-named)after-named\\1',
+                            'patternToEmulatedNumberedGroupIndex': {
+                                '3': 1,
+                            },
+                        },
+                    ],
+                },
+                {
+                    'name': 'I_RAW_REGEX',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_OPTIMISED',
+                            'chars': 'before-nestedin-nestedafter-nested',
+                            'patternToEmulatedNumberedGroupIndex': {},
+                        },
+                    ],
+                },
+                {
+                    'name': 'I_RAW_REGEX',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_OPTIMISED',
+                            'chars':
+                                'before-non-capture(?:in-non-capture)after-non-capture',
+                            'patternToEmulatedNumberedGroupIndex': {},
+                        },
+                    ],
+                },
+                {
+                    'name': 'I_RAW_REGEX',
+                    'chunks': [
+                        {
+                            'name': 'I_RAW_OPTIMISED',
+                            'chars': 'before-noopafter-noop',
+                            'patternToEmulatedNumberedGroupIndex': {},
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+});

--- a/test/integration/compiler/intermediateToPattern/group/nonCapturingGroupTest.ts
+++ b/test/integration/compiler/intermediateToPattern/group/nonCapturingGroupTest.ts
@@ -15,7 +15,7 @@ import { SinonStubbedInstance } from 'sinon';
 import IntermediateToPatternCompiler from '../../../../../src/IntermediateToPatternCompiler';
 import IntermediateRepresentation from '../../../../../src/IntermediateRepresentation';
 
-describe('IR-to-Pattern compiler non-capturing group integration', () => {
+describe('IR-to-Pattern compiler (unoptimised) non-capturing group integration', () => {
     let compiler: IntermediateToPatternCompiler;
 
     beforeEach(() => {
@@ -30,10 +30,16 @@ describe('IR-to-Pattern compiler non-capturing group integration', () => {
         intermediateRepresentation.getFlags.returns(DEFAULT_FLAGS);
         intermediateRepresentation.getTranspilerRepresentation.returns({
             'name': 'I_PATTERN',
+            'capturingGroups': [],
             'components': [
                 {
                     'name': 'I_NON_CAPTURING_GROUP',
-                    'components': [{ 'name': 'I_RAW_REGEX', 'chars': 'X' }],
+                    'components': [
+                        {
+                            'name': 'I_RAW_REGEX',
+                            'chunks': [{ 'name': 'I_RAW_CHARS', chars: 'X' }],
+                        },
+                    ],
                 },
             ],
         });
@@ -41,6 +47,21 @@ describe('IR-to-Pattern compiler non-capturing group integration', () => {
         const pattern = compiler.compile(intermediateRepresentation);
 
         // Note we just use the native syntax for this.
-        expect(pattern.toString()).to.equal('/(?:X)/dg');
+        expect(pattern.toStructure()).to.deep.equal({
+            type: 'pattern',
+            capturingGroups: [],
+            components: [
+                {
+                    type: 'non-capturing-group',
+                    components: [
+                        {
+                            type: 'native',
+                            chars: 'X',
+                            patternToEmulatedNumberedGroupIndex: [],
+                        },
+                    ],
+                },
+            ],
+        });
     });
 });

--- a/test/integration/compiler/intermediateToPattern/quantifier/modifier/minimiserTest.ts
+++ b/test/integration/compiler/intermediateToPattern/quantifier/modifier/minimiserTest.ts
@@ -15,7 +15,7 @@ import IntermediateToPatternCompiler from '../../../../../../src/IntermediateToP
 import IntermediateRepresentation from '../../../../../../src/IntermediateRepresentation';
 import sinon = require('sinon');
 
-describe('IR-to-Pattern compiler quantifier minimiser integration', () => {
+describe('IR-to-Pattern compiler (unoptimised) quantifier minimiser integration', () => {
     let compiler: IntermediateToPatternCompiler;
 
     beforeEach(() => {
@@ -30,17 +30,36 @@ describe('IR-to-Pattern compiler quantifier minimiser integration', () => {
         intermediateRepresentation.getFlags.returns(DEFAULT_FLAGS);
         intermediateRepresentation.getTranspilerRepresentation.returns({
             'name': 'I_PATTERN',
+            'capturingGroups': [],
             'components': [
                 {
                     'name': 'I_MINIMISING_QUANTIFIER',
                     'quantifier': '*',
-                    'component': { 'name': 'I_RAW_REGEX', 'chars': 'X' },
+                    'component': {
+                        'name': 'I_RAW_REGEX',
+                        'chunks': [{ 'name': 'I_RAW_CHARS', chars: 'X' }],
+                    },
                 },
             ],
         });
 
         const pattern = compiler.compile(intermediateRepresentation);
 
-        expect(pattern.toString()).to.equal('/X*?/dg');
+        expect(pattern.toStructure()).to.deep.equal({
+            type: 'pattern',
+            capturingGroups: [],
+            components: [
+                {
+                    type: 'minimising-quantifier',
+                    minimumMatches: 0,
+                    maximumMatches: null,
+                    component: {
+                        type: 'native',
+                        chars: 'X',
+                        patternToEmulatedNumberedGroupIndex: [],
+                    },
+                },
+            ],
+        });
     });
 });

--- a/test/integration/compiler/intermediateToPattern/quantifier/modifier/possessiveTest.ts
+++ b/test/integration/compiler/intermediateToPattern/quantifier/modifier/possessiveTest.ts
@@ -15,7 +15,7 @@ import IntermediateToPatternCompiler from '../../../../../../src/IntermediateToP
 import IntermediateRepresentation from '../../../../../../src/IntermediateRepresentation';
 import sinon = require('sinon');
 
-describe('IR-to-Pattern compiler possessive quantifier integration', () => {
+describe('IR-to-Pattern compiler (unoptimised) possessive quantifier integration', () => {
     let compiler: IntermediateToPatternCompiler;
 
     beforeEach(() => {
@@ -30,17 +30,36 @@ describe('IR-to-Pattern compiler possessive quantifier integration', () => {
         intermediateRepresentation.getFlags.returns(DEFAULT_FLAGS);
         intermediateRepresentation.getTranspilerRepresentation.returns({
             'name': 'I_PATTERN',
+            'capturingGroups': [],
             'components': [
                 {
                     'name': 'I_POSSESSIVE_QUANTIFIER',
                     'quantifier': '*',
-                    'component': { 'name': 'I_RAW_REGEX', 'chars': 'X' },
+                    'component': {
+                        'name': 'I_RAW_REGEX',
+                        'chunks': [{ 'name': 'I_RAW_CHARS', chars: 'X' }],
+                    },
                 },
             ],
         });
 
         const pattern = compiler.compile(intermediateRepresentation);
 
-        expect(pattern.toString()).to.equal('/(?=(X*))\\1/dg');
+        expect(pattern.toStructure()).to.deep.equal({
+            type: 'pattern',
+            capturingGroups: [],
+            components: [
+                {
+                    type: 'possessive-quantifier',
+                    minimumMatches: 0,
+                    maximumMatches: null,
+                    component: {
+                        type: 'native',
+                        chars: 'X',
+                        patternToEmulatedNumberedGroupIndex: [],
+                    },
+                },
+            ],
+        });
     });
 });

--- a/test/integration/compiler/intermediateToPattern/rawRegexTest.ts
+++ b/test/integration/compiler/intermediateToPattern/rawRegexTest.ts
@@ -15,7 +15,7 @@ import IntermediateToPatternCompiler from '../../../../src/IntermediateToPattern
 import IntermediateRepresentation from '../../../../src/IntermediateRepresentation';
 import { SinonStubbedInstance } from 'sinon';
 
-describe('IR-to-Pattern compiler raw regex characters integration', () => {
+describe('IR-to-Pattern compiler (unoptimised) raw regex characters integration', () => {
     let compiler: IntermediateToPatternCompiler;
 
     beforeEach(() => {
@@ -30,20 +30,36 @@ describe('IR-to-Pattern compiler raw regex characters integration', () => {
         intermediateRepresentation.getFlags.returns(DEFAULT_FLAGS);
         intermediateRepresentation.getTranspilerRepresentation.returns({
             'name': 'I_PATTERN',
+            'capturingGroups': [],
             'components': [
                 {
                     'name': 'I_RAW_REGEX',
-                    'chars': 'hello',
+                    'chunks': [{ 'name': 'I_RAW_CHARS', chars: 'hello' }],
                 },
                 {
                     'name': 'I_RAW_REGEX',
-                    'chars': 'world',
+                    'chunks': [{ 'name': 'I_RAW_CHARS', chars: 'world' }],
                 },
             ],
         });
 
         const pattern = compiler.compile(intermediateRepresentation);
 
-        expect(pattern.toString()).to.equal('/helloworld/dg');
+        expect(pattern.toStructure()).to.deep.equal({
+            type: 'pattern',
+            capturingGroups: [],
+            components: [
+                {
+                    type: 'native',
+                    chars: 'hello',
+                    patternToEmulatedNumberedGroupIndex: [],
+                },
+                {
+                    type: 'native',
+                    chars: 'world',
+                    patternToEmulatedNumberedGroupIndex: [],
+                },
+            ],
+        });
     });
 });

--- a/test/integration/match/alternationTest.ts
+++ b/test/integration/match/alternationTest.ts
@@ -11,25 +11,55 @@ import emulator from '../../../src';
 import { expect } from 'chai';
 
 describe('Alternation match integration', () => {
-    it('should be able to match an alternation', () => {
-        const matcher = emulator.compile('my (initial|final) text');
+    describe('in optimised mode', () => {
+        it('should be able to match an alternation', () => {
+            const matcher = emulator.compile('my (initial|final) text');
 
-        const match = matcher.matchOne('my final text');
+            const match = matcher.matchOne('my final text');
 
-        expect(match).not.to.be.null;
-        expect(match?.getCaptureCount()).to.equal(2);
-        expect(match?.getNumberedCapture(0)).to.equal('my final text');
-        expect(match?.getNumberedCapture(1)).to.equal('final');
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(2);
+            expect(match?.getNumberedCapture(0)).to.equal('my final text');
+            expect(match?.getNumberedCapture(1)).to.equal('final');
+        });
+
+        it("should be able to match an alternation's empty alternative", () => {
+            const matcher = emulator.compile('my (initial|final|) text');
+
+            const match = matcher.matchOne('my  text');
+
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(2);
+            expect(match?.getNumberedCapture(0)).to.equal('my  text');
+            expect(match?.getNumberedCapture(1)).to.equal('');
+        });
     });
 
-    it("should be able to match an alternation's empty alternative", () => {
-        const matcher = emulator.compile('my (initial|final|) text');
+    describe('in unoptimised mode', () => {
+        it('should be able to match an alternation', () => {
+            const matcher = emulator.compile('my (initial|final) text', {
+                optimise: false,
+            });
 
-        const match = matcher.matchOne('my  text');
+            const match = matcher.matchOne('my final text');
 
-        expect(match).not.to.be.null;
-        expect(match?.getCaptureCount()).to.equal(2);
-        expect(match?.getNumberedCapture(0)).to.equal('my  text');
-        expect(match?.getNumberedCapture(1)).to.equal('');
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(2);
+            expect(match?.getNumberedCapture(0)).to.equal('my final text');
+            expect(match?.getNumberedCapture(1)).to.equal('final');
+        });
+
+        it("should be able to match an alternation's empty alternative", () => {
+            const matcher = emulator.compile('my (initial|final|) text', {
+                optimise: false,
+            });
+
+            const match = matcher.matchOne('my  text');
+
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(2);
+            expect(match?.getNumberedCapture(0)).to.equal('my  text');
+            expect(match?.getNumberedCapture(1)).to.equal('');
+        });
     });
 });

--- a/test/integration/match/assertion/simple/endOfStringTest.ts
+++ b/test/integration/match/assertion/simple/endOfStringTest.ts
@@ -11,21 +11,43 @@ import emulator from '../../../../../src';
 import { expect } from 'chai';
 
 describe('End-of-string simple (anchor) assertion match integration', () => {
-    it('should be able to match the end of string', () => {
-        const matcher = emulator.compile('mytext$');
+    describe('in optimised mode', () => {
+        it('should be able to match the end of string', () => {
+            const matcher = emulator.compile('mytext$');
 
-        const match = matcher.matchOne('here is mytext');
+            const match = matcher.matchOne('here is mytext');
 
-        expect(match).not.to.be.null;
-        expect(match?.getCaptureCount()).to.equal(1);
-        expect(match?.getNumberedCapture(0)).to.equal('mytext');
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(1);
+            expect(match?.getNumberedCapture(0)).to.equal('mytext');
+        });
+
+        it('should be able to fail to match the end of string', () => {
+            const matcher = emulator.compile('mytext$');
+
+            const match = matcher.matchOne('mytext with something after it');
+
+            expect(match).to.be.null;
+        });
     });
 
-    it('should be able to fail to match the end of string', () => {
-        const matcher = emulator.compile('mytext$');
+    describe('in unoptimised mode', () => {
+        it('should be able to match the end of string', () => {
+            const matcher = emulator.compile('mytext$', { optimise: false });
 
-        const match = matcher.matchOne('mytext with something after it');
+            const match = matcher.matchOne('here is mytext');
 
-        expect(match).to.be.null;
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(1);
+            expect(match?.getNumberedCapture(0)).to.equal('mytext');
+        });
+
+        it('should be able to fail to match the end of string', () => {
+            const matcher = emulator.compile('mytext$', { optimise: false });
+
+            const match = matcher.matchOne('mytext with something after it');
+
+            expect(match).to.be.null;
+        });
     });
 });

--- a/test/integration/match/assertion/simple/startOfStringTest.ts
+++ b/test/integration/match/assertion/simple/startOfStringTest.ts
@@ -11,21 +11,43 @@ import emulator from '../../../../../src';
 import { expect } from 'chai';
 
 describe('Start-of-string simple (anchor) assertion match integration', () => {
-    it('should be able to match the start of string', () => {
-        const matcher = emulator.compile('^mytext');
+    describe('in optimised mode', () => {
+        it('should be able to match the start of string', () => {
+            const matcher = emulator.compile('^mytext');
 
-        const match = matcher.matchOne('mytext and some more');
+            const match = matcher.matchOne('mytext and some more');
 
-        expect(match).not.to.be.null;
-        expect(match?.getCaptureCount()).to.equal(1);
-        expect(match?.getNumberedCapture(0)).to.equal('mytext');
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(1);
+            expect(match?.getNumberedCapture(0)).to.equal('mytext');
+        });
+
+        it('should be able to fail to match the start of string', () => {
+            const matcher = emulator.compile('^mytext');
+
+            const match = matcher.matchOne('something before and then mytext');
+
+            expect(match).to.be.null;
+        });
     });
 
-    it('should be able to fail to match the start of string', () => {
-        const matcher = emulator.compile('^mytext');
+    describe('in unoptimised mode', () => {
+        it('should be able to match the start of string', () => {
+            const matcher = emulator.compile('^mytext', { optimise: false });
 
-        const match = matcher.matchOne('something before and then mytext');
+            const match = matcher.matchOne('mytext and some more');
 
-        expect(match).to.be.null;
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(1);
+            expect(match?.getNumberedCapture(0)).to.equal('mytext');
+        });
+
+        it('should be able to fail to match the start of string', () => {
+            const matcher = emulator.compile('^mytext', { optimise: false });
+
+            const match = matcher.matchOne('something before and then mytext');
+
+            expect(match).to.be.null;
+        });
     });
 });

--- a/test/integration/match/characterClassTest.ts
+++ b/test/integration/match/characterClassTest.ts
@@ -11,13 +11,29 @@ import emulator from '../../../src';
 import { expect } from 'chai';
 
 describe('Character class match integration', () => {
-    it('should be able to match a character class', () => {
-        const matcher = emulator.compile('my [a-c] text');
+    describe('in optimised mode', () => {
+        it('should be able to match a character class', () => {
+            const matcher = emulator.compile('my [a-c] text');
 
-        const match = matcher.matchOne('my b text');
+            const match = matcher.matchOne('my b text');
 
-        expect(match).not.to.be.null;
-        expect(match?.getCaptureCount()).to.equal(1);
-        expect(match?.getNumberedCapture(0)).to.equal('my b text');
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(1);
+            expect(match?.getNumberedCapture(0)).to.equal('my b text');
+        });
+    });
+
+    describe('in unoptimised mode', () => {
+        it('should be able to match a character class', () => {
+            const matcher = emulator.compile('my [a-c] text', {
+                optimise: false,
+            });
+
+            const match = matcher.matchOne('my b text');
+
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(1);
+            expect(match?.getNumberedCapture(0)).to.equal('my b text');
+        });
     });
 });

--- a/test/integration/match/dotTest.ts
+++ b/test/integration/match/dotTest.ts
@@ -11,31 +11,63 @@ import emulator from '../../../src';
 import { expect } from 'chai';
 
 describe('Dot (all) match integration', () => {
-    it('should be able to match a string with a regex containing a dot', () => {
-        const matcher = emulator.compile('my n.me');
+    describe('in optimised mode', () => {
+        it('should be able to match a string with a regex containing a dot', () => {
+            const matcher = emulator.compile('my n.me');
 
-        const match = matcher.matchOne('my nAme');
+            const match = matcher.matchOne('my nAme');
 
-        expect(match).not.to.be.null;
-        expect(match?.getCaptureCount()).to.equal(1);
-        expect(match?.getNumberedCapture(0)).to.equal('my nAme');
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(1);
+            expect(match?.getNumberedCapture(0)).to.equal('my nAme');
+        });
+
+        // See dotAll mode tests for when dot can match newlines.
+        it('should not match the dot against a carriage-return character outside dotAll mode', () => {
+            const matcher = emulator.compile('my n.me');
+
+            const match = matcher.matchOne('my n\rme');
+
+            expect(match).to.be.null;
+        });
+
+        // See dotAll mode tests for when dot can match newlines.
+        it('should not match the dot against a linefeed character outside dotAll mode', () => {
+            const matcher = emulator.compile('my n.me');
+
+            const match = matcher.matchOne('my n\nme');
+
+            expect(match).to.be.null;
+        });
     });
 
-    // See dotAll mode tests for when dot can match newlines.
-    it('should not match the dot against a carriage-return character outside dotAll mode', () => {
-        const matcher = emulator.compile('my n.me');
+    describe('in unoptimised mode', () => {
+        it('should be able to match a string with a regex containing a dot', () => {
+            const matcher = emulator.compile('my n.me', { optimise: false });
 
-        const match = matcher.matchOne('my n\rme');
+            const match = matcher.matchOne('my nAme');
 
-        expect(match).to.be.null;
-    });
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(1);
+            expect(match?.getNumberedCapture(0)).to.equal('my nAme');
+        });
 
-    // See dotAll mode tests for when dot can match newlines.
-    it('should not match the dot against a linefeed character outside dotAll mode', () => {
-        const matcher = emulator.compile('my n.me');
+        // See dotAll mode tests for when dot can match newlines.
+        it('should not match the dot against a carriage-return character outside dotAll mode', () => {
+            const matcher = emulator.compile('my n.me', { optimise: false });
 
-        const match = matcher.matchOne('my n\nme');
+            const match = matcher.matchOne('my n\rme');
 
-        expect(match).to.be.null;
+            expect(match).to.be.null;
+        });
+
+        // See dotAll mode tests for when dot can match newlines.
+        it('should not match the dot against a linefeed character outside dotAll mode', () => {
+            const matcher = emulator.compile('my n.me', { optimise: false });
+
+            const match = matcher.matchOne('my n\nme');
+
+            expect(match).to.be.null;
+        });
     });
 });

--- a/test/integration/match/dotTest.ts
+++ b/test/integration/match/dotTest.ts
@@ -20,4 +20,22 @@ describe('Dot (all) match integration', () => {
         expect(match?.getCaptureCount()).to.equal(1);
         expect(match?.getNumberedCapture(0)).to.equal('my nAme');
     });
+
+    // See dotAll mode tests for when dot can match newlines.
+    it('should not match the dot against a carriage-return character outside dotAll mode', () => {
+        const matcher = emulator.compile('my n.me');
+
+        const match = matcher.matchOne('my n\rme');
+
+        expect(match).to.be.null;
+    });
+
+    // See dotAll mode tests for when dot can match newlines.
+    it('should not match the dot against a linefeed character outside dotAll mode', () => {
+        const matcher = emulator.compile('my n.me');
+
+        const match = matcher.matchOne('my n\nme');
+
+        expect(match).to.be.null;
+    });
 });

--- a/test/integration/match/genericCharacterTypesTest.ts
+++ b/test/integration/match/genericCharacterTypesTest.ts
@@ -11,13 +11,29 @@ import emulator from '../../../src';
 import { expect } from 'chai';
 
 describe('Generic character types match integration', () => {
-    it('should be able to match a string with a regex containing a decimal digit escape sequence', () => {
-        const matcher = emulator.compile('my number \\d first');
+    describe('in optimised mode', () => {
+        it('should be able to match a string with a regex containing a decimal digit escape sequence', () => {
+            const matcher = emulator.compile('my number \\d first');
 
-        const match = matcher.matchOne('my number 7 first');
+            const match = matcher.matchOne('my number 7 first');
 
-        expect(match).not.to.be.null;
-        expect(match?.getCaptureCount()).to.equal(1);
-        expect(match?.getNumberedCapture(0)).to.equal('my number 7 first');
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(1);
+            expect(match?.getNumberedCapture(0)).to.equal('my number 7 first');
+        });
+    });
+
+    describe('in unoptimised mode', () => {
+        it('should be able to match a string with a regex containing a decimal digit escape sequence', () => {
+            const matcher = emulator.compile('my number \\d first', {
+                optimise: false,
+            });
+
+            const match = matcher.matchOne('my number 7 first');
+
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(1);
+            expect(match?.getNumberedCapture(0)).to.equal('my number 7 first');
+        });
     });
 });

--- a/test/integration/match/group/capturingGroupTest.ts
+++ b/test/integration/match/group/capturingGroupTest.ts
@@ -11,14 +11,31 @@ import emulator from '../../../../src';
 import { expect } from 'chai';
 
 describe('Capturing group match integration', () => {
-    it('should be able to capture a capturing group', () => {
-        const matcher = emulator.compile('my (captured) text');
+    describe('in optimised mode', () => {
+        it('should be able to capture a capturing group', () => {
+            const matcher = emulator.compile('my (captured) text');
 
-        const match = matcher.matchOne('my captured text');
+            const match = matcher.matchOne('my captured text');
 
-        expect(match).not.to.be.null;
-        expect(match?.getCaptureCount()).to.equal(2);
-        expect(match?.getNumberedCapture(0)).to.equal('my captured text');
-        expect(match?.getNumberedCapture(1)).to.equal('captured');
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(2);
+            expect(match?.getNumberedCapture(0)).to.equal('my captured text');
+            expect(match?.getNumberedCapture(1)).to.equal('captured');
+        });
+    });
+
+    describe('in unoptimised mode', () => {
+        it('should be able to capture a capturing group', () => {
+            const matcher = emulator.compile('my (captured) text', {
+                optimise: false,
+            });
+
+            const match = matcher.matchOne('my captured text');
+
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(2);
+            expect(match?.getNumberedCapture(0)).to.equal('my captured text');
+            expect(match?.getNumberedCapture(1)).to.equal('captured');
+        });
     });
 });

--- a/test/integration/match/group/namedCapturingGroupTest.ts
+++ b/test/integration/match/group/namedCapturingGroupTest.ts
@@ -11,16 +11,35 @@ import emulator from '../../../../src';
 import { expect } from 'chai';
 
 describe('Named capturing group match integration', () => {
-    it('should be able to capture a named capturing group', () => {
-        const matcher = emulator.compile('my (?<grabbed>captured) text');
+    describe('in optimised mode', () => {
+        it('should be able to capture a named capturing group', () => {
+            const matcher = emulator.compile('my (?<grabbed>captured) text');
 
-        const match = matcher.matchOne('my captured text');
+            const match = matcher.matchOne('my captured text');
 
-        expect(match).not.to.be.null;
-        expect(match?.getCaptureCount()).to.equal(2);
-        // Named captures are also available by their index.
-        expect(match?.getNumberedCapture(0)).to.equal('my captured text');
-        expect(match?.getNumberedCapture(1)).to.equal('captured');
-        expect(match?.getNamedCapture('grabbed')).to.equal('captured');
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(2);
+            // Named captures are also available by their index.
+            expect(match?.getNumberedCapture(0)).to.equal('my captured text');
+            expect(match?.getNumberedCapture(1)).to.equal('captured');
+            expect(match?.getNamedCapture('grabbed')).to.equal('captured');
+        });
+    });
+
+    describe('in unoptimised mode', () => {
+        it('should be able to capture a named capturing group', () => {
+            const matcher = emulator.compile('my (?<grabbed>captured) text', {
+                optimise: false,
+            });
+
+            const match = matcher.matchOne('my captured text');
+
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(2);
+            // Named captures are also available by their index.
+            expect(match?.getNumberedCapture(0)).to.equal('my captured text');
+            expect(match?.getNumberedCapture(1)).to.equal('captured');
+            expect(match?.getNamedCapture('grabbed')).to.equal('captured');
+        });
     });
 });

--- a/test/integration/match/group/nonCapturingGroupTest.ts
+++ b/test/integration/match/group/nonCapturingGroupTest.ts
@@ -11,13 +11,33 @@ import emulator from '../../../../src';
 import { expect } from 'chai';
 
 describe('Non-capturing group match integration', () => {
-    it('should be able to group part of a pattern without capturing', () => {
-        const matcher = emulator.compile('my (?:one two)* text');
+    describe('in optimised mode', () => {
+        it('should be able to group part of a pattern without capturing', () => {
+            const matcher = emulator.compile('my (?:one two)* text');
 
-        const match = matcher.matchOne('my one twoone two text');
+            const match = matcher.matchOne('my one twoone two text');
 
-        expect(match).not.to.be.null;
-        expect(match?.getCaptureCount()).to.equal(1);
-        expect(match?.getNumberedCapture(0)).to.equal('my one twoone two text');
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(1);
+            expect(match?.getNumberedCapture(0)).to.equal(
+                'my one twoone two text'
+            );
+        });
+    });
+
+    describe('in unoptimised mode', () => {
+        it('should be able to group part of a pattern without capturing', () => {
+            const matcher = emulator.compile('my (?:one two)* text', {
+                optimise: false,
+            });
+
+            const match = matcher.matchOne('my one twoone two text');
+
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(1);
+            expect(match?.getNumberedCapture(0)).to.equal(
+                'my one twoone two text'
+            );
+        });
     });
 });

--- a/test/integration/match/indexCaptureTest.ts
+++ b/test/integration/match/indexCaptureTest.ts
@@ -11,49 +11,104 @@ import emulator from '../../../src';
 import { expect } from 'chai';
 
 describe('Match index capture integration', () => {
-    it('should be able to capture start and end indices for numbered capturing groups', () => {
-        const matcher = emulator.compile('my (first) and (second) groups');
+    describe('in optimised mode', () => {
+        it('should be able to capture start and end indices for numbered capturing groups', () => {
+            const matcher = emulator.compile('my (first) and (second) groups');
 
-        const match = matcher.matchOne('my first and second groups');
+            const match = matcher.matchOne('my first and second groups');
 
-        expect(match).not.to.be.null;
-        expect(match?.getCaptureCount()).to.equal(3);
-        expect(match?.getNumberedCaptures()).to.deep.equal([
-            'my first and second groups',
-            'first',
-            'second',
-        ]);
-        expect(match?.getNumberedCapture(0)).to.equal(
-            'my first and second groups'
-        );
-        expect(match?.getNumberedCaptureStart(0)).to.equal(0);
-        expect(match?.getNumberedCaptureEnd(0)).to.equal(26);
-        expect(match?.getNumberedCapture(1)).to.equal('first');
-        expect(match?.getNumberedCaptureStart(1)).to.equal(3);
-        expect(match?.getNumberedCaptureEnd(1)).to.equal(8);
-        expect(match?.getNumberedCapture(2)).to.equal('second');
-        expect(match?.getNumberedCaptureStart(2)).to.equal(13);
-        expect(match?.getNumberedCaptureEnd(2)).to.equal(19);
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(3);
+            expect(match?.getNumberedCaptures()).to.deep.equal([
+                'my first and second groups',
+                'first',
+                'second',
+            ]);
+            expect(match?.getNumberedCapture(0)).to.equal(
+                'my first and second groups'
+            );
+            expect(match?.getNumberedCaptureStart(0)).to.equal(0);
+            expect(match?.getNumberedCaptureEnd(0)).to.equal(26);
+            expect(match?.getNumberedCapture(1)).to.equal('first');
+            expect(match?.getNumberedCaptureStart(1)).to.equal(3);
+            expect(match?.getNumberedCaptureEnd(1)).to.equal(8);
+            expect(match?.getNumberedCapture(2)).to.equal('second');
+            expect(match?.getNumberedCaptureStart(2)).to.equal(13);
+            expect(match?.getNumberedCaptureEnd(2)).to.equal(19);
+        });
+
+        it('should be able to capture start and end indices for named capturing groups', () => {
+            const matcher = emulator.compile(
+                'my (?<group1>first) and (?<group2>second) groups'
+            );
+
+            const match = matcher.matchOne('my first and second groups');
+
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(3);
+            expect(match?.getNamedCaptures()).to.deep.equal({
+                'group1': 'first',
+                'group2': 'second',
+            });
+            expect(match?.getNamedCapture('group1')).to.equal('first');
+            expect(match?.getNamedCaptureStart('group1')).to.equal(3);
+            expect(match?.getNamedCaptureEnd('group1')).to.equal(8);
+            expect(match?.getNamedCapture('group2')).to.equal('second');
+            expect(match?.getNamedCaptureStart('group2')).to.equal(13);
+            expect(match?.getNamedCaptureEnd('group2')).to.equal(19);
+        });
     });
 
-    it('should be able to capture start and end indices for named capturing groups', () => {
-        const matcher = emulator.compile(
-            'my (?<group1>first) and (?<group2>second) groups'
-        );
+    describe('in unoptimised mode', () => {
+        it('should be able to capture start and end indices for numbered capturing groups', () => {
+            const matcher = emulator.compile('my (first) and (second) groups', {
+                optimise: false,
+            });
 
-        const match = matcher.matchOne('my first and second groups');
+            const match = matcher.matchOne('my first and second groups');
 
-        expect(match).not.to.be.null;
-        expect(match?.getCaptureCount()).to.equal(3);
-        expect(match?.getNamedCaptures()).to.deep.equal({
-            'group1': 'first',
-            'group2': 'second',
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(3);
+            expect(match?.getNumberedCaptures()).to.deep.equal([
+                'my first and second groups',
+                'first',
+                'second',
+            ]);
+            expect(match?.getNumberedCapture(0)).to.equal(
+                'my first and second groups'
+            );
+            expect(match?.getNumberedCaptureStart(0)).to.equal(0);
+            expect(match?.getNumberedCaptureEnd(0)).to.equal(26);
+            expect(match?.getNumberedCapture(1)).to.equal('first');
+            expect(match?.getNumberedCaptureStart(1)).to.equal(3);
+            expect(match?.getNumberedCaptureEnd(1)).to.equal(8);
+            expect(match?.getNumberedCapture(2)).to.equal('second');
+            expect(match?.getNumberedCaptureStart(2)).to.equal(13);
+            expect(match?.getNumberedCaptureEnd(2)).to.equal(19);
         });
-        expect(match?.getNamedCapture('group1')).to.equal('first');
-        expect(match?.getNamedCaptureStart('group1')).to.equal(3);
-        expect(match?.getNamedCaptureEnd('group1')).to.equal(8);
-        expect(match?.getNamedCapture('group2')).to.equal('second');
-        expect(match?.getNamedCaptureStart('group2')).to.equal(13);
-        expect(match?.getNamedCaptureEnd('group2')).to.equal(19);
+
+        it('should be able to capture start and end indices for named capturing groups', () => {
+            const matcher = emulator.compile(
+                'my (?<group1>first) and (?<group2>second) groups',
+                {
+                    optimise: false,
+                }
+            );
+
+            const match = matcher.matchOne('my first and second groups');
+
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(3);
+            expect(match?.getNamedCaptures()).to.deep.equal({
+                'group1': 'first',
+                'group2': 'second',
+            });
+            expect(match?.getNamedCapture('group1')).to.equal('first');
+            expect(match?.getNamedCaptureStart('group1')).to.equal(3);
+            expect(match?.getNamedCaptureEnd('group1')).to.equal(8);
+            expect(match?.getNamedCapture('group2')).to.equal('second');
+            expect(match?.getNamedCaptureStart('group2')).to.equal(13);
+            expect(match?.getNamedCaptureEnd('group2')).to.equal(19);
+        });
     });
 });

--- a/test/integration/match/literalTest.ts
+++ b/test/integration/match/literalTest.ts
@@ -11,14 +11,28 @@ import emulator from '../../../src';
 import { expect } from 'chai';
 
 describe('Literal match integration', () => {
-    it('should be able to match a string with a regex containing only a literal', () => {
-        const matcher = emulator.compile('myliteral');
+    describe('in optimised mode', () => {
+        it('should be able to match a string with a regex containing only a literal', () => {
+            const matcher = emulator.compile('myliteral');
 
-        const match = matcher.matchOne('myliteral');
+            const match = matcher.matchOne('myliteral');
 
-        expect(match).not.to.be.null;
-        expect(match?.getCaptureCount()).to.equal(1);
-        expect(match?.getNumberedCapture(0)).to.equal('myliteral');
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(1);
+            expect(match?.getNumberedCapture(0)).to.equal('myliteral');
+        });
+    });
+
+    describe('in unoptimised mode', () => {
+        it('should be able to match a string with a regex containing only a literal', () => {
+            const matcher = emulator.compile('myliteral', { optimise: false });
+
+            const match = matcher.matchOne('myliteral');
+
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(1);
+            expect(match?.getNumberedCapture(0)).to.equal('myliteral');
+        });
     });
 
     describe('in non-extended mode', () => {

--- a/test/integration/match/mode/anchoredTest.ts
+++ b/test/integration/match/mode/anchoredTest.ts
@@ -11,28 +11,63 @@ import emulator from '../../../../src';
 import { expect } from 'chai';
 
 describe('Anchored mode match integration', () => {
-    it('should match at the start position or previous match end', () => {
-        const matcher = emulator.compile('(my)text', { anchored: true });
+    describe('in optimised mode', () => {
+        it('should match at the start position or previous match end', () => {
+            const matcher = emulator.compile('(my)text', { anchored: true });
 
-        const matches = matcher.matchAll('pad mytextmytext', 4);
+            const matches = matcher.matchAll('pad mytextmytext', 4);
 
-        expect(matches).to.have.length(2);
-        expect(matches[0].getCaptureCount()).to.equal(2);
-        expect(matches[0].getStart()).to.equal(4);
-        expect(matches[0].getNumberedCapture(0)).to.equal('mytext');
-        expect(matches[0].getNumberedCapture(1)).to.equal('my');
+            expect(matches).to.have.length(2);
+            expect(matches[0].getCaptureCount()).to.equal(2);
+            expect(matches[0].getStart()).to.equal(4);
+            expect(matches[0].getNumberedCapture(0)).to.equal('mytext');
+            expect(matches[0].getNumberedCapture(1)).to.equal('my');
 
-        expect(matches[1].getCaptureCount()).to.equal(2);
-        expect(matches[1].getStart()).to.equal(10);
-        expect(matches[1].getNumberedCapture(0)).to.equal('mytext');
-        expect(matches[1].getNumberedCapture(1)).to.equal('my');
+            expect(matches[1].getCaptureCount()).to.equal(2);
+            expect(matches[1].getStart()).to.equal(10);
+            expect(matches[1].getNumberedCapture(0)).to.equal('mytext');
+            expect(matches[1].getNumberedCapture(1)).to.equal('my');
+        });
+
+        it('should fail to match later candidates beyond the start position', () => {
+            const matcher = emulator.compile('(my)text', { anchored: true });
+
+            const matches = matcher.matchAll('pad mytextmytext');
+
+            expect(matches).to.have.length(0);
+        });
     });
 
-    it('should fail to match later candidates beyond the start position', () => {
-        const matcher = emulator.compile('(my)text', { anchored: true });
+    describe('in unoptimised mode', () => {
+        it('should match at the start position or previous match end', () => {
+            const matcher = emulator.compile('(my)text', {
+                anchored: true,
+                optimise: false,
+            });
 
-        const matches = matcher.matchAll('pad mytextmytext');
+            const matches = matcher.matchAll('pad mytextmytext', 4);
 
-        expect(matches).to.have.length(0);
+            expect(matches).to.have.length(2);
+            expect(matches[0].getCaptureCount()).to.equal(2);
+            expect(matches[0].getStart()).to.equal(4);
+            expect(matches[0].getNumberedCapture(0)).to.equal('mytext');
+            expect(matches[0].getNumberedCapture(1)).to.equal('my');
+
+            expect(matches[1].getCaptureCount()).to.equal(2);
+            expect(matches[1].getStart()).to.equal(10);
+            expect(matches[1].getNumberedCapture(0)).to.equal('mytext');
+            expect(matches[1].getNumberedCapture(1)).to.equal('my');
+        });
+
+        it('should fail to match later candidates beyond the start position', () => {
+            const matcher = emulator.compile('(my)text', {
+                anchored: true,
+                optimise: false,
+            });
+
+            const matches = matcher.matchAll('pad mytextmytext');
+
+            expect(matches).to.have.length(0);
+        });
     });
 });

--- a/test/integration/match/mode/caselessTest.ts
+++ b/test/integration/match/mode/caselessTest.ts
@@ -11,22 +11,48 @@ import emulator from '../../../../src';
 import { expect } from 'chai';
 
 describe('Caseless mode match integration', () => {
-    it('should be able to match case-insensitively in caseless mode', () => {
-        const matcher = emulator.compile('my[t]eXt', { caseless: true });
+    describe('in optimised mode', () => {
+        it('should be able to match case-insensitively in caseless mode', () => {
+            const matcher = emulator.compile('my[t]eXt', { caseless: true });
 
-        const matches = matcher.matchAll('MyTExTmytextMYtext');
+            const matches = matcher.matchAll('MyTExTmytextMYtext');
 
-        expect(matches).to.have.length(3);
-        expect(matches[0].getCaptureCount()).to.equal(1);
-        expect(matches[0].getStart()).to.equal(0);
-        expect(matches[0].getNumberedCapture(0)).to.equal('MyTExT');
+            expect(matches).to.have.length(3);
+            expect(matches[0].getCaptureCount()).to.equal(1);
+            expect(matches[0].getStart()).to.equal(0);
+            expect(matches[0].getNumberedCapture(0)).to.equal('MyTExT');
 
-        expect(matches[1].getCaptureCount()).to.equal(1);
-        expect(matches[1].getStart()).to.equal(6);
-        expect(matches[1].getNumberedCapture(0)).to.equal('mytext');
+            expect(matches[1].getCaptureCount()).to.equal(1);
+            expect(matches[1].getStart()).to.equal(6);
+            expect(matches[1].getNumberedCapture(0)).to.equal('mytext');
 
-        expect(matches[2].getCaptureCount()).to.equal(1);
-        expect(matches[2].getStart()).to.equal(12);
-        expect(matches[2].getNumberedCapture(0)).to.equal('MYtext');
+            expect(matches[2].getCaptureCount()).to.equal(1);
+            expect(matches[2].getStart()).to.equal(12);
+            expect(matches[2].getNumberedCapture(0)).to.equal('MYtext');
+        });
+    });
+
+    describe('in unoptimised mode', () => {
+        it('should be able to match case-insensitively in caseless mode', () => {
+            const matcher = emulator.compile('my[t]eXt', {
+                caseless: true,
+                optimise: false,
+            });
+
+            const matches = matcher.matchAll('MyTExTmytextMYtext');
+
+            expect(matches).to.have.length(3);
+            expect(matches[0].getCaptureCount()).to.equal(1);
+            expect(matches[0].getStart()).to.equal(0);
+            expect(matches[0].getNumberedCapture(0)).to.equal('MyTExT');
+
+            expect(matches[1].getCaptureCount()).to.equal(1);
+            expect(matches[1].getStart()).to.equal(6);
+            expect(matches[1].getNumberedCapture(0)).to.equal('mytext');
+
+            expect(matches[2].getCaptureCount()).to.equal(1);
+            expect(matches[2].getStart()).to.equal(12);
+            expect(matches[2].getNumberedCapture(0)).to.equal('MYtext');
+        });
     });
 });

--- a/test/integration/match/mode/dotAllTest.ts
+++ b/test/integration/match/mode/dotAllTest.ts
@@ -1,0 +1,29 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import emulator from '../../../../src';
+import { expect } from 'chai';
+
+describe('Dot-all mode match integration', () => {
+    it('should be able to match dot against newline characters too', () => {
+        const matcher = emulator.compile('start.*end', { dotAll: true });
+
+        const match = matcher.matchOne(
+            // Note we check use of both carriage-return and linefeed.
+            'start blah blah\nline 2\rline 3\nand end'
+        );
+
+        expect(match).not.to.be.null;
+        expect(match?.getCaptureCount()).to.equal(1);
+        expect(match?.getStart()).to.equal(0);
+        expect(match?.getNumberedCapture(0)).to.equal(
+            'start blah blah\nline 2\rline 3\nand end'
+        );
+    });
+});

--- a/test/integration/match/mode/dotAllTest.ts
+++ b/test/integration/match/mode/dotAllTest.ts
@@ -11,19 +11,42 @@ import emulator from '../../../../src';
 import { expect } from 'chai';
 
 describe('Dot-all mode match integration', () => {
-    it('should be able to match dot against newline characters too', () => {
-        const matcher = emulator.compile('start.*end', { dotAll: true });
+    describe('in optimised mode', () => {
+        it('should be able to match dot against newline characters too', () => {
+            const matcher = emulator.compile('start.*end', { dotAll: true });
 
-        const match = matcher.matchOne(
-            // Note we check use of both carriage-return and linefeed.
-            'start blah blah\nline 2\rline 3\nand end'
-        );
+            const match = matcher.matchOne(
+                // Note we check use of both carriage-return and linefeed.
+                'start blah blah\nline 2\rline 3\nand end'
+            );
 
-        expect(match).not.to.be.null;
-        expect(match?.getCaptureCount()).to.equal(1);
-        expect(match?.getStart()).to.equal(0);
-        expect(match?.getNumberedCapture(0)).to.equal(
-            'start blah blah\nline 2\rline 3\nand end'
-        );
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(1);
+            expect(match?.getStart()).to.equal(0);
+            expect(match?.getNumberedCapture(0)).to.equal(
+                'start blah blah\nline 2\rline 3\nand end'
+            );
+        });
+    });
+
+    describe('in unoptimised mode', () => {
+        it('should be able to match dot against newline characters too', () => {
+            const matcher = emulator.compile('start.*end', {
+                dotAll: true,
+                optimise: false,
+            });
+
+            const match = matcher.matchOne(
+                // Note we check use of both carriage-return and linefeed.
+                'start blah blah\nline 2\rline 3\nand end'
+            );
+
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(1);
+            expect(match?.getStart()).to.equal(0);
+            expect(match?.getNumberedCapture(0)).to.equal(
+                'start blah blah\nline 2\rline 3\nand end'
+            );
+        });
     });
 });

--- a/test/integration/match/mode/extendedTest.ts
+++ b/test/integration/match/mode/extendedTest.ts
@@ -11,20 +11,45 @@ import emulator from '../../../../src';
 import { expect } from 'chai';
 
 describe('Extended mode match integration', () => {
-    it('should ignore whitespace and comments inside the pattern except for inside character classes', () => {
-        const matcher = emulator.compile(
-            ' my ( text ) + +  # My comment to be ignored\n  [ ]+  (?<grabbed> after ) ',
-            { extended: true }
-        );
+    describe('in optimised mode', () => {
+        it('should ignore whitespace and comments inside the pattern except for inside character classes', () => {
+            const matcher = emulator.compile(
+                ' my ( text ) + +  # My comment to be ignored\n  [ ]+  (?<grabbed> after ) ',
+                { extended: true }
+            );
 
-        const match = matcher.matchOne('pad mytexttexttext   after');
+            const match = matcher.matchOne('pad mytexttexttext   after');
 
-        expect(match).not.to.be.null;
-        expect(match?.getCaptureCount()).to.equal(3);
-        expect(match?.getStart()).to.equal(4);
-        expect(match?.getNumberedCapture(0)).to.equal('mytexttexttext   after');
-        expect(match?.getNumberedCapture(1)).to.equal('text');
-        expect(match?.getNumberedCapture(2)).to.equal('after');
-        expect(match?.getNamedCapture('grabbed')).to.equal('after');
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(3);
+            expect(match?.getStart()).to.equal(4);
+            expect(match?.getNumberedCapture(0)).to.equal(
+                'mytexttexttext   after'
+            );
+            expect(match?.getNumberedCapture(1)).to.equal('text');
+            expect(match?.getNumberedCapture(2)).to.equal('after');
+            expect(match?.getNamedCapture('grabbed')).to.equal('after');
+        });
+    });
+
+    describe('in unoptimised mode', () => {
+        it('should ignore whitespace and comments inside the pattern except for inside character classes', () => {
+            const matcher = emulator.compile(
+                ' my ( text ) + +  # My comment to be ignored\n  [ ]+  (?<grabbed> after ) ',
+                { extended: true, optimise: false }
+            );
+
+            const match = matcher.matchOne('pad mytexttexttext   after');
+
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(3);
+            expect(match?.getStart()).to.equal(4);
+            expect(match?.getNumberedCapture(0)).to.equal(
+                'mytexttexttext   after'
+            );
+            expect(match?.getNumberedCapture(1)).to.equal('text');
+            expect(match?.getNumberedCapture(2)).to.equal('after');
+            expect(match?.getNamedCapture('grabbed')).to.equal('after');
+        });
     });
 });

--- a/test/integration/match/mode/multilineTest.ts
+++ b/test/integration/match/mode/multilineTest.ts
@@ -11,25 +11,54 @@ import emulator from '../../../../src';
 import { expect } from 'chai';
 
 describe('Multiline mode match integration', () => {
-    it('should be able to match with ^ and $ as also start- and end-of-line in multiline mode', () => {
-        const matcher = emulator.compile('^(my)text$', { multiline: true });
+    describe('in optimised mode', () => {
+        it('should be able to match with ^ and $ as also start- and end-of-line in multiline mode', () => {
+            const matcher = emulator.compile('^(my)text$', { multiline: true });
 
-        const matches = matcher.matchAll('mytext\nmytext\nmytext');
+            const matches = matcher.matchAll('mytext\nmytext\nmytext');
 
-        expect(matches).to.have.length(3);
-        expect(matches[0].getCaptureCount()).to.equal(2);
-        expect(matches[0].getStart()).to.equal(0);
-        expect(matches[0].getNumberedCapture(0)).to.equal('mytext');
-        expect(matches[0].getNumberedCapture(1)).to.equal('my');
+            expect(matches).to.have.length(3);
+            expect(matches[0].getCaptureCount()).to.equal(2);
+            expect(matches[0].getStart()).to.equal(0);
+            expect(matches[0].getNumberedCapture(0)).to.equal('mytext');
+            expect(matches[0].getNumberedCapture(1)).to.equal('my');
 
-        expect(matches[1].getCaptureCount()).to.equal(2);
-        expect(matches[1].getStart()).to.equal(7);
-        expect(matches[1].getNumberedCapture(0)).to.equal('mytext');
-        expect(matches[1].getNumberedCapture(1)).to.equal('my');
+            expect(matches[1].getCaptureCount()).to.equal(2);
+            expect(matches[1].getStart()).to.equal(7);
+            expect(matches[1].getNumberedCapture(0)).to.equal('mytext');
+            expect(matches[1].getNumberedCapture(1)).to.equal('my');
 
-        expect(matches[2].getCaptureCount()).to.equal(2);
-        expect(matches[2].getStart()).to.equal(14);
-        expect(matches[2].getNumberedCapture(0)).to.equal('mytext');
-        expect(matches[2].getNumberedCapture(1)).to.equal('my');
+            expect(matches[2].getCaptureCount()).to.equal(2);
+            expect(matches[2].getStart()).to.equal(14);
+            expect(matches[2].getNumberedCapture(0)).to.equal('mytext');
+            expect(matches[2].getNumberedCapture(1)).to.equal('my');
+        });
+    });
+
+    describe('in unoptimised mode', () => {
+        it('should be able to match with ^ and $ as also start- and end-of-line in multiline mode', () => {
+            const matcher = emulator.compile('^(my)text$', {
+                multiline: true,
+                optimise: false,
+            });
+
+            const matches = matcher.matchAll('mytext\nmytext\nmytext');
+
+            expect(matches).to.have.length(3);
+            expect(matches[0].getCaptureCount()).to.equal(2);
+            expect(matches[0].getStart()).to.equal(0);
+            expect(matches[0].getNumberedCapture(0)).to.equal('mytext');
+            expect(matches[0].getNumberedCapture(1)).to.equal('my');
+
+            expect(matches[1].getCaptureCount()).to.equal(2);
+            expect(matches[1].getStart()).to.equal(7);
+            expect(matches[1].getNumberedCapture(0)).to.equal('mytext');
+            expect(matches[1].getNumberedCapture(1)).to.equal('my');
+
+            expect(matches[2].getCaptureCount()).to.equal(2);
+            expect(matches[2].getStart()).to.equal(14);
+            expect(matches[2].getNumberedCapture(0)).to.equal('mytext');
+            expect(matches[2].getNumberedCapture(1)).to.equal('my');
+        });
     });
 });

--- a/test/integration/match/multipleTest.ts
+++ b/test/integration/match/multipleTest.ts
@@ -11,15 +11,45 @@ import emulator from '../../../src';
 import { expect } from 'chai';
 
 describe('Multiple match integration', () => {
-    it('should be able to match multiple occurrences of the pattern in the subject string', () => {
-        const matcher = emulator.compile('my literal');
+    describe('in optimised mode', () => {
+        it('should be able to match multiple occurrences of the pattern in the subject string', () => {
+            const matcher = emulator.compile('my literal');
 
-        const matches = matcher.matchAll(
-            'my literal and then my literal again'
-        );
+            const matches = matcher.matchAll(
+                'my literal and then my literal again'
+            );
 
-        expect(matches).to.have.length(2);
-        expect(matches[0].getCaptureCount()).to.equal(1);
-        expect(matches[0].getNumberedCapture(0)).to.equal('my literal');
+            expect(matches).to.have.length(2);
+            expect(matches[0].getCaptureCount()).to.equal(1);
+            expect(matches[0].getStart()).to.equal(0);
+            expect(matches[0].getEnd()).to.equal(10);
+            expect(matches[0].getNumberedCapture(0)).to.equal('my literal');
+
+            expect(matches[1].getCaptureCount()).to.equal(1);
+            expect(matches[1].getStart()).to.equal(20);
+            expect(matches[1].getEnd()).to.equal(30);
+            expect(matches[1].getNumberedCapture(0)).to.equal('my literal');
+        });
+    });
+
+    describe('in unoptimised mode', () => {
+        it('should be able to match multiple occurrences of the pattern in the subject string', () => {
+            const matcher = emulator.compile('my literal', { optimise: false });
+
+            const matches = matcher.matchAll(
+                'my literal and then my literal again'
+            );
+
+            expect(matches).to.have.length(2);
+            expect(matches[0].getCaptureCount()).to.equal(1);
+            expect(matches[0].getStart()).to.equal(0);
+            expect(matches[0].getEnd()).to.equal(10);
+            expect(matches[0].getNumberedCapture(0)).to.equal('my literal');
+
+            expect(matches[1].getCaptureCount()).to.equal(1);
+            expect(matches[1].getStart()).to.equal(20);
+            expect(matches[1].getEnd()).to.equal(30);
+            expect(matches[1].getNumberedCapture(0)).to.equal('my literal');
+        });
     });
 });

--- a/test/integration/match/quantifier/modifier/minimiserTest.ts
+++ b/test/integration/match/quantifier/modifier/minimiserTest.ts
@@ -11,14 +11,31 @@ import emulator from '../../../../../src';
 import { expect } from 'chai';
 
 describe('Quantifier minimiser match integration', () => {
-    it('should be able to make a quantifier match lazily', () => {
-        const matcher = emulator.compile('my (a[ab]*?a)');
+    describe('in optimised mode', () => {
+        it('should be able to make a quantifier match lazily', () => {
+            const matcher = emulator.compile('my (a[ab]*?a)');
 
-        const match = matcher.matchOne('my abbbabbba text');
+            const match = matcher.matchOne('my abbbabbba text');
 
-        expect(match).not.to.be.null;
-        expect(match?.getCaptureCount()).to.equal(2);
-        expect(match?.getNumberedCapture(0)).to.equal('my abbba');
-        expect(match?.getNumberedCapture(1)).to.equal('abbba');
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(2);
+            expect(match?.getNumberedCapture(0)).to.equal('my abbba');
+            expect(match?.getNumberedCapture(1)).to.equal('abbba');
+        });
+    });
+
+    describe('in unoptimised mode', () => {
+        it('should be able to make a quantifier match lazily', () => {
+            const matcher = emulator.compile('my (a[ab]*?a)', {
+                optimise: false,
+            });
+
+            const match = matcher.matchOne('my abbbabbba text');
+
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(2);
+            expect(match?.getNumberedCapture(0)).to.equal('my abbba');
+            expect(match?.getNumberedCapture(1)).to.equal('abbba');
+        });
     });
 });

--- a/test/integration/match/quantifier/modifier/possessiveTest.ts
+++ b/test/integration/match/quantifier/modifier/possessiveTest.ts
@@ -11,34 +11,71 @@ import emulator from '../../../../../src';
 import { expect } from 'chai';
 
 describe('Possessive quantifier match integration', () => {
-    it('should be able to match a run', () => {
-        const matcher = emulator.compile('my (a*+)(?<gr>b)');
+    describe('in optimised mode', () => {
+        it('should be able to match a run', () => {
+            const matcher = emulator.compile('my (a*+)(?<gr>b)');
 
-        const match = matcher.matchOne('my aaaaaab');
+            const match = matcher.matchOne('my aaaaaab');
 
-        expect(match).not.to.be.null;
-        expect(match?.getCaptureCount()).to.equal(3);
-        expect(match?.getNumberedCapture(0)).to.equal('my aaaaaab');
-        expect(match?.getNumberedCaptureStart(0)).to.equal(0);
-        expect(match?.getNumberedCaptureEnd(0)).to.equal(10);
-        expect(match?.getNumberedCapture(1)).to.equal('aaaaaa');
-        expect(match?.getNumberedCaptureStart(1)).to.equal(3);
-        expect(match?.getNumberedCaptureEnd(1)).to.equal(9);
-        expect(match?.getNumberedCapture(2)).to.equal('b');
-        expect(match?.getNumberedCaptureStart(2)).to.equal(9);
-        expect(match?.getNumberedCaptureEnd(2)).to.equal(10);
-        expect(match?.getNamedCapture('gr')).to.equal('b');
-        expect(match?.getNamedCaptureStart('gr')).to.equal(9);
-        expect(match?.getNamedCaptureEnd('gr')).to.equal(10);
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(3);
+            expect(match?.getNumberedCapture(0)).to.equal('my aaaaaab');
+            expect(match?.getNumberedCaptureStart(0)).to.equal(0);
+            expect(match?.getNumberedCaptureEnd(0)).to.equal(10);
+            expect(match?.getNumberedCapture(1)).to.equal('aaaaaa');
+            expect(match?.getNumberedCaptureStart(1)).to.equal(3);
+            expect(match?.getNumberedCaptureEnd(1)).to.equal(9);
+            expect(match?.getNumberedCapture(2)).to.equal('b');
+            expect(match?.getNumberedCaptureStart(2)).to.equal(9);
+            expect(match?.getNumberedCaptureEnd(2)).to.equal(10);
+            expect(match?.getNamedCapture('gr')).to.equal('b');
+            expect(match?.getNamedCaptureStart('gr')).to.equal(9);
+            expect(match?.getNamedCaptureEnd('gr')).to.equal(10);
+        });
+
+        it('should not allow backtracking (match atomically)', () => {
+            // Possessive match is unable to give up the final "a"
+            // for the next pattern char to match and consume.
+            const matcher = emulator.compile('my (a*+)a');
+
+            const match = matcher.matchOne('my aaaaaaa');
+
+            expect(match).to.be.null;
+        });
     });
 
-    it('should not allow backtracking (match atomically)', () => {
-        // Possessive match is unable to give up the final "a"
-        // for the next pattern char to match and consume.
-        const matcher = emulator.compile('my (a*+)a');
+    describe('in unoptimised mode', () => {
+        it('should be able to match a run', () => {
+            const matcher = emulator.compile('my (a*+)(?<gr>b)', {
+                optimise: false,
+            });
 
-        const match = matcher.matchOne('my aaaaaaa');
+            const match = matcher.matchOne('my aaaaaab');
 
-        expect(match).to.be.null;
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(3);
+            expect(match?.getNumberedCapture(0)).to.equal('my aaaaaab');
+            expect(match?.getNumberedCaptureStart(0)).to.equal(0);
+            expect(match?.getNumberedCaptureEnd(0)).to.equal(10);
+            expect(match?.getNumberedCapture(1)).to.equal('aaaaaa');
+            expect(match?.getNumberedCaptureStart(1)).to.equal(3);
+            expect(match?.getNumberedCaptureEnd(1)).to.equal(9);
+            expect(match?.getNumberedCapture(2)).to.equal('b');
+            expect(match?.getNumberedCaptureStart(2)).to.equal(9);
+            expect(match?.getNumberedCaptureEnd(2)).to.equal(10);
+            expect(match?.getNamedCapture('gr')).to.equal('b');
+            expect(match?.getNamedCaptureStart('gr')).to.equal(9);
+            expect(match?.getNamedCaptureEnd('gr')).to.equal(10);
+        });
+
+        it('should not allow backtracking (match atomically)', () => {
+            // Possessive match is unable to give up the final "a"
+            // for the next pattern char to match and consume.
+            const matcher = emulator.compile('my (a*+)a', { optimise: false });
+
+            const match = matcher.matchOne('my aaaaaaa');
+
+            expect(match).to.be.null;
+        });
     });
 });

--- a/test/integration/match/quantifier/oneOrMoreTest.ts
+++ b/test/integration/match/quantifier/oneOrMoreTest.ts
@@ -11,36 +11,103 @@ import emulator from '../../../../src';
 import { expect } from 'chai';
 
 describe('One-or-more quantifier match integration', () => {
-    it('should be able to match a quantifier one time', () => {
-        const matcher = emulator.compile('my (possible)+ text');
+    describe('in optimised mode', () => {
+        it('should be able to match a quantifier one time', () => {
+            const matcher = emulator.compile('my (possible)+ text');
 
-        const match = matcher.matchOne('my possible text');
+            const match = matcher.matchOne('my possible text');
 
-        expect(match).not.to.be.null;
-        expect(match?.getCaptureCount()).to.equal(2);
-        expect(match?.getNumberedCapture(0)).to.equal('my possible text');
-        expect(match?.getNumberedCapture(1)).to.equal('possible');
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(2);
+            expect(match?.getNumberedCapture(0)).to.equal('my possible text');
+            expect(match?.getNumberedCapture(1)).to.equal('possible');
+        });
+
+        it('should be able to match a quantifier multiple times', () => {
+            const matcher = emulator.compile('my (possible)+ text');
+
+            const match = matcher.matchOne('my possiblepossiblepossible text');
+
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(2);
+            expect(match?.getNumberedCapture(0)).to.equal(
+                'my possiblepossiblepossible text'
+            );
+            // Note that only the last capture is kept.
+            expect(match?.getNumberedCapture(1)).to.equal('possible');
+        });
+
+        it('should not be able to match a quantifier zero times', () => {
+            const matcher = emulator.compile('my (possible)+ text');
+
+            const match = matcher.matchOne('my  text');
+
+            expect(match).to.be.null;
+        });
+
+        it('should backtrack when needed', () => {
+            const matcher = emulator.compile('my ([ab]+baaa)b text');
+
+            const match = matcher.matchOne('my abaaab text');
+
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(2);
+            expect(match?.getNumberedCapture(0)).to.equal('my abaaab text');
+            expect(match?.getNumberedCapture(1)).to.equal('abaaa');
+        });
     });
 
-    it('should be able to match a quantifier multiple times', () => {
-        const matcher = emulator.compile('my (possible)+ text');
+    describe('in unoptimised mode', () => {
+        it('should be able to match a quantifier one time', () => {
+            const matcher = emulator.compile('my (possible)+ text', {
+                optimise: false,
+            });
 
-        const match = matcher.matchOne('my possiblepossiblepossible text');
+            const match = matcher.matchOne('my possible text');
 
-        expect(match).not.to.be.null;
-        expect(match?.getCaptureCount()).to.equal(2);
-        expect(match?.getNumberedCapture(0)).to.equal(
-            'my possiblepossiblepossible text'
-        );
-        // Note that only the last capture is kept.
-        expect(match?.getNumberedCapture(1)).to.equal('possible');
-    });
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(2);
+            expect(match?.getNumberedCapture(0)).to.equal('my possible text');
+            expect(match?.getNumberedCapture(1)).to.equal('possible');
+        });
 
-    it('should not be able to match a quantifier zero times', () => {
-        const matcher = emulator.compile('my (possible)+ text');
+        it('should be able to match a quantifier multiple times', () => {
+            const matcher = emulator.compile('my (possible)+ text', {
+                optimise: false,
+            });
 
-        const match = matcher.matchOne('my  text');
+            const match = matcher.matchOne('my possiblepossiblepossible text');
 
-        expect(match).to.be.null;
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(2);
+            expect(match?.getNumberedCapture(0)).to.equal(
+                'my possiblepossiblepossible text'
+            );
+            // Note that only the last capture is kept.
+            expect(match?.getNumberedCapture(1)).to.equal('possible');
+        });
+
+        it('should not be able to match a quantifier zero times', () => {
+            const matcher = emulator.compile('my (possible)+ text', {
+                optimise: false,
+            });
+
+            const match = matcher.matchOne('my  text');
+
+            expect(match).to.be.null;
+        });
+
+        it('should backtrack when needed', () => {
+            const matcher = emulator.compile('my ([ab]+baaa)b text', {
+                optimise: false,
+            });
+
+            const match = matcher.matchOne('my abaaab text');
+
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(2);
+            expect(match?.getNumberedCapture(0)).to.equal('my abaaab text');
+            expect(match?.getNumberedCapture(1)).to.equal('abaaa');
+        });
     });
 });

--- a/test/integration/match/quantifier/optionalTest.ts
+++ b/test/integration/match/quantifier/optionalTest.ts
@@ -11,34 +11,75 @@ import emulator from '../../../../src';
 import { expect } from 'chai';
 
 describe('Optional quantifier match integration', () => {
-    it('should be able to match a quantifier one time', () => {
-        const matcher = emulator.compile('my (possible)? text');
+    describe('in optimised mode', () => {
+        it('should be able to match a quantifier one time', () => {
+            const matcher = emulator.compile('my (possible)? text');
 
-        const match = matcher.matchOne('my possible text');
+            const match = matcher.matchOne('my possible text');
 
-        expect(match).not.to.be.null;
-        expect(match?.getCaptureCount()).to.equal(2);
-        expect(match?.getNumberedCapture(0)).to.equal('my possible text');
-        expect(match?.getNumberedCapture(1)).to.equal('possible');
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(2);
+            expect(match?.getNumberedCapture(0)).to.equal('my possible text');
+            expect(match?.getNumberedCapture(1)).to.equal('possible');
+        });
+
+        it('should be able to match a quantifier zero times', () => {
+            const matcher = emulator.compile('my (possible)? text');
+
+            const match = matcher.matchOne('my  text');
+
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(2);
+            expect(match?.getNumberedCapture(0)).to.equal('my  text');
+            // Note that a capture that was not reached has a value of null.
+            expect(match?.getNumberedCapture(1)).to.be.null;
+        });
+
+        it('should not be able to match a quantifier multiple times', () => {
+            const matcher = emulator.compile('my (possible)? text');
+
+            const match = matcher.matchOne('my possiblepossiblepossible text');
+
+            expect(match).to.be.null;
+        });
     });
 
-    it('should be able to match a quantifier zero times', () => {
-        const matcher = emulator.compile('my (possible)? text');
+    describe('in unoptimised mode', () => {
+        it('should be able to match a quantifier one time', () => {
+            const matcher = emulator.compile('my (possible)? text', {
+                optimise: false,
+            });
 
-        const match = matcher.matchOne('my  text');
+            const match = matcher.matchOne('my possible text');
 
-        expect(match).not.to.be.null;
-        expect(match?.getCaptureCount()).to.equal(2);
-        expect(match?.getNumberedCapture(0)).to.equal('my  text');
-        // Note that a capture that was not reached has a value of null.
-        expect(match?.getNumberedCapture(1)).to.be.null;
-    });
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(2);
+            expect(match?.getNumberedCapture(0)).to.equal('my possible text');
+            expect(match?.getNumberedCapture(1)).to.equal('possible');
+        });
 
-    it('should not be able to match a quantifier multiple times', () => {
-        const matcher = emulator.compile('my (possible)? text');
+        it('should be able to match a quantifier zero times', () => {
+            const matcher = emulator.compile('my (possible)? text', {
+                optimise: false,
+            });
 
-        const match = matcher.matchOne('my possiblepossiblepossible text');
+            const match = matcher.matchOne('my  text');
 
-        expect(match).to.be.null;
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(2);
+            expect(match?.getNumberedCapture(0)).to.equal('my  text');
+            // Note that a capture that was not reached has a value of null.
+            expect(match?.getNumberedCapture(1)).to.be.null;
+        });
+
+        it('should not be able to match a quantifier multiple times', () => {
+            const matcher = emulator.compile('my (possible)? text', {
+                optimise: false,
+            });
+
+            const match = matcher.matchOne('my possiblepossiblepossible text');
+
+            expect(match).to.be.null;
+        });
     });
 });

--- a/test/integration/match/quantifier/zeroOrMoreTest.ts
+++ b/test/integration/match/quantifier/zeroOrMoreTest.ts
@@ -11,39 +11,110 @@ import emulator from '../../../../src';
 import { expect } from 'chai';
 
 describe('Zero-or-more quantifier match integration', () => {
-    it('should be able to match a quantifier zero times', () => {
-        const matcher = emulator.compile('my (possible)* text');
+    describe('in optimised mode', () => {
+        it('should be able to match a quantifier zero times', () => {
+            const matcher = emulator.compile('my (possible)* text');
 
-        const match = matcher.matchOne('my  text');
+            const match = matcher.matchOne('my  text');
 
-        expect(match).not.to.be.null;
-        expect(match?.getCaptureCount()).to.equal(2);
-        expect(match?.getNumberedCapture(0)).to.equal('my  text');
-        expect(match?.getNumberedCapture(1)).to.be.null;
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(2);
+            expect(match?.getNumberedCapture(0)).to.equal('my  text');
+            expect(match?.getNumberedCapture(1)).to.be.null;
+        });
+
+        it('should be able to match a quantifier one time', () => {
+            const matcher = emulator.compile('my (possible)* text');
+
+            const match = matcher.matchOne('my possible text');
+
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(2);
+            expect(match?.getNumberedCapture(0)).to.equal('my possible text');
+            expect(match?.getNumberedCapture(1)).to.equal('possible');
+        });
+
+        it('should be able to match a quantifier multiple times', () => {
+            const matcher = emulator.compile('my (possible)* text');
+
+            const match = matcher.matchOne('my possiblepossiblepossible text');
+
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(2);
+            expect(match?.getNumberedCapture(0)).to.equal(
+                'my possiblepossiblepossible text'
+            );
+            // Note that only the last capture is kept.
+            expect(match?.getNumberedCapture(1)).to.equal('possible');
+        });
+
+        it('should backtrack when needed', () => {
+            const matcher = emulator.compile('my ([ab]*baaa)b text');
+
+            const match = matcher.matchOne('my abaaab text');
+
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(2);
+            expect(match?.getNumberedCapture(0)).to.equal('my abaaab text');
+            expect(match?.getNumberedCapture(1)).to.equal('abaaa');
+        });
     });
 
-    it('should be able to match a quantifier one time', () => {
-        const matcher = emulator.compile('my (possible)* text');
+    describe('in unoptimised mode', () => {
+        it('should be able to match a quantifier zero times', () => {
+            const matcher = emulator.compile('my (possible)* text', {
+                optimise: false,
+            });
 
-        const match = matcher.matchOne('my possible text');
+            const match = matcher.matchOne('my  text');
 
-        expect(match).not.to.be.null;
-        expect(match?.getCaptureCount()).to.equal(2);
-        expect(match?.getNumberedCapture(0)).to.equal('my possible text');
-        expect(match?.getNumberedCapture(1)).to.equal('possible');
-    });
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(2);
+            expect(match?.getNumberedCapture(0)).to.equal('my  text');
+            // Note that a capture that was not reached has a value of null.
+            expect(match?.getNumberedCapture(1)).to.be.null;
+        });
 
-    it('should be able to match a quantifier multiple times', () => {
-        const matcher = emulator.compile('my (possible)* text');
+        it('should be able to match a quantifier one time', () => {
+            const matcher = emulator.compile('my (possible)* text', {
+                optimise: false,
+            });
 
-        const match = matcher.matchOne('my possiblepossiblepossible text');
+            const match = matcher.matchOne('my possible text');
 
-        expect(match).not.to.be.null;
-        expect(match?.getCaptureCount()).to.equal(2);
-        expect(match?.getNumberedCapture(0)).to.equal(
-            'my possiblepossiblepossible text'
-        );
-        // Note that only the last capture is kept.
-        expect(match?.getNumberedCapture(1)).to.equal('possible');
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(2);
+            expect(match?.getNumberedCapture(0)).to.equal('my possible text');
+            expect(match?.getNumberedCapture(1)).to.equal('possible');
+        });
+
+        it('should be able to match a quantifier multiple times', () => {
+            const matcher = emulator.compile('my (possible)* text', {
+                optimise: false,
+            });
+
+            const match = matcher.matchOne('my possiblepossiblepossible text');
+
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(2);
+            expect(match?.getNumberedCapture(0)).to.equal(
+                'my possiblepossiblepossible text'
+            );
+            // Note that only the last capture is kept.
+            expect(match?.getNumberedCapture(1)).to.equal('possible');
+        });
+
+        it('should backtrack when needed', () => {
+            const matcher = emulator.compile('my ([ab]*baaa)b text', {
+                optimise: false,
+            });
+
+            const match = matcher.matchOne('my abaaab text');
+
+            expect(match).not.to.be.null;
+            expect(match?.getCaptureCount()).to.equal(2);
+            expect(match?.getNumberedCapture(0)).to.equal('my abaaab text');
+            expect(match?.getNumberedCapture(1)).to.equal('abaaa');
+        });
     });
 });

--- a/test/integration/match/startOffsetTest.ts
+++ b/test/integration/match/startOffsetTest.ts
@@ -91,6 +91,36 @@ describe('Start offset match integration', () => {
                 expect(match?.getNumberedCapture(0)).to.equal('myliteral');
             });
 
+            it('should backtrack the top level of an un-anchored regex along the string', () => {
+                // First capturing group will make zero-length matches along the string until "a" is reached.
+                const matcher = emulator.compile('((?:^1234.*?)?)a(..)d', {
+                    optimise: false,
+                });
+
+                const match = matcher.matchOne('abcd 1234 axyd', 5);
+
+                expect(match).not.to.be.null;
+                expect(match?.getCaptureCount()).to.equal(3);
+                expect(match?.getNumberedCapture(0)).to.equal('axyd');
+                expect(match?.getNumberedCaptureStart(0)).to.equal(10);
+                expect(match?.getNumberedCapture(1)).to.equal('');
+                expect(match?.getNumberedCaptureStart(1)).to.equal(10);
+                expect(match?.getNumberedCapture(2)).to.equal('xy');
+                expect(match?.getNumberedCaptureStart(2)).to.equal(11);
+            });
+
+            it('should not backtrack the top level of an anchored regex along the string', () => {
+                // First capturing group will make zero-length matches along the string until "a" is reached.
+                const matcher = emulator.compile('((?:^1234.*?)?)a(..)d', {
+                    anchored: true,
+                    optimise: false,
+                });
+
+                const match = matcher.matchOne('abcd 1234 axyd', 5);
+
+                expect(match).to.be.null;
+            });
+
             it('should fail to match if the start offset is beyond all candidates', () => {
                 const matcher = emulator.compile('myliteral', {
                     optimise: false,

--- a/test/integration/match/startOffsetTest.ts
+++ b/test/integration/match/startOffsetTest.ts
@@ -12,42 +12,94 @@ import { expect } from 'chai';
 
 describe('Start offset match integration', () => {
     describe('matchAll()', () => {
-        it('should be able to match a string from a specified offset', () => {
-            const matcher = emulator.compile('myliteral');
+        describe('in optimised mode', () => {
+            it('should be able to match a string from a specified offset', () => {
+                const matcher = emulator.compile('myliteral');
 
-            const matches = matcher.matchAll('here is myliteral', 5);
+                const matches = matcher.matchAll('here is myliteral', 5);
 
-            expect(matches).to.have.length(1);
-            expect(matches[0].getCaptureCount()).to.equal(1);
-            expect(matches[0].getNumberedCapture(0)).to.equal('myliteral');
+                expect(matches).to.have.length(1);
+                expect(matches[0].getCaptureCount()).to.equal(1);
+                expect(matches[0].getNumberedCapture(0)).to.equal('myliteral');
+            });
+
+            it('should fail to match if the start offset is beyond all candidates', () => {
+                const matcher = emulator.compile('myliteral');
+
+                const matches = matcher.matchAll('here is myliteral', 9);
+
+                expect(matches).to.have.length(0);
+            });
         });
 
-        it('should fail to match if the start offset is beyond all candidates', () => {
-            const matcher = emulator.compile('myliteral');
+        describe('in unoptimised mode', () => {
+            it('should be able to match a string from a specified offset', () => {
+                const matcher = emulator.compile('myliteral', {
+                    optimise: false,
+                });
 
-            const matches = matcher.matchAll('here is myliteral', 9);
+                const matches = matcher.matchAll('here is myliteral', 5);
 
-            expect(matches).to.have.length(0);
+                expect(matches).to.have.length(1);
+                expect(matches[0].getCaptureCount()).to.equal(1);
+                expect(matches[0].getNumberedCapture(0)).to.equal('myliteral');
+            });
+
+            it('should fail to match if the start offset is beyond all candidates', () => {
+                const matcher = emulator.compile('myliteral', {
+                    optimise: false,
+                });
+
+                const matches = matcher.matchAll('here is myliteral', 9);
+
+                expect(matches).to.have.length(0);
+            });
         });
     });
 
     describe('matchOne()', () => {
-        it('should be able to match a string from a specified offset', () => {
-            const matcher = emulator.compile('myliteral');
+        describe('in optimised mode', () => {
+            it('should be able to match a string from a specified offset', () => {
+                const matcher = emulator.compile('myliteral');
 
-            const match = matcher.matchOne('here is myliteral', 5);
+                const match = matcher.matchOne('here is myliteral', 5);
 
-            expect(match).not.to.be.null;
-            expect(match?.getCaptureCount()).to.equal(1);
-            expect(match?.getNumberedCapture(0)).to.equal('myliteral');
+                expect(match).not.to.be.null;
+                expect(match?.getCaptureCount()).to.equal(1);
+                expect(match?.getNumberedCapture(0)).to.equal('myliteral');
+            });
+
+            it('should fail to match if the start offset is beyond all candidates', () => {
+                const matcher = emulator.compile('myliteral');
+
+                const match = matcher.matchOne('here is myliteral', 9);
+
+                expect(match).to.be.null;
+            });
         });
 
-        it('should fail to match if the start offset is beyond all candidates', () => {
-            const matcher = emulator.compile('myliteral');
+        describe('in unoptimised mode', () => {
+            it('should be able to match a string from a specified offset', () => {
+                const matcher = emulator.compile('myliteral', {
+                    optimise: false,
+                });
 
-            const match = matcher.matchOne('here is myliteral', 9);
+                const match = matcher.matchOne('here is myliteral', 5);
 
-            expect(match).to.be.null;
+                expect(match).not.to.be.null;
+                expect(match?.getCaptureCount()).to.equal(1);
+                expect(match?.getNumberedCapture(0)).to.equal('myliteral');
+            });
+
+            it('should fail to match if the start offset is beyond all candidates', () => {
+                const matcher = emulator.compile('myliteral', {
+                    optimise: false,
+                });
+
+                const match = matcher.matchOne('here is myliteral', 9);
+
+                expect(match).to.be.null;
+            });
         });
     });
 });

--- a/test/integration/match/zeroWidthMatchTest.ts
+++ b/test/integration/match/zeroWidthMatchTest.ts
@@ -11,19 +11,39 @@ import emulator from '../../../src';
 import { expect } from 'chai';
 
 describe('Zero-width match handling integration', () => {
-    it('should not cause an infinite loop when using an empty match with .matchAll(...)', () => {
-        const matcher = emulator.compile('a*');
+    describe('in optimised mode', () => {
+        it('should not cause an infinite loop when using an empty match with .matchAll(...)', () => {
+            const matcher = emulator.compile('a*');
 
-        // Note that "a*" will match nothing at each position but still be successful.
-        const matches = matcher.matchAll('xyzxyz');
+            // Note that "a*" will match nothing at each position but still be successful.
+            const matches = matcher.matchAll('xyzxyz');
 
-        expect(matches).to.have.length(7);
-        expect(matches[0].getCapture()).to.equal('');
-        expect(matches[1].getCapture()).to.equal('');
-        expect(matches[2].getCapture()).to.equal('');
-        expect(matches[3].getCapture()).to.equal('');
-        expect(matches[4].getCapture()).to.equal('');
-        expect(matches[5].getCapture()).to.equal('');
-        expect(matches[6].getCapture()).to.equal('');
+            expect(matches).to.have.length(7);
+            expect(matches[0].getCapture()).to.equal('');
+            expect(matches[1].getCapture()).to.equal('');
+            expect(matches[2].getCapture()).to.equal('');
+            expect(matches[3].getCapture()).to.equal('');
+            expect(matches[4].getCapture()).to.equal('');
+            expect(matches[5].getCapture()).to.equal('');
+            expect(matches[6].getCapture()).to.equal('');
+        });
+    });
+
+    describe('in unoptimised mode', () => {
+        it('should not cause an infinite loop when using an empty match with .matchAll(...)', () => {
+            const matcher = emulator.compile('a*', { optimise: false });
+
+            // Note that "a*" will match nothing at each position but still be successful.
+            const matches = matcher.matchAll('xyzxyz');
+
+            expect(matches).to.have.length(7);
+            expect(matches[0].getCapture()).to.equal('');
+            expect(matches[1].getCapture()).to.equal('');
+            expect(matches[2].getCapture()).to.equal('');
+            expect(matches[3].getCapture()).to.equal('');
+            expect(matches[4].getCapture()).to.equal('');
+            expect(matches[5].getCapture()).to.equal('');
+            expect(matches[6].getCapture()).to.equal('');
+        });
     });
 });

--- a/test/unit/IntermediateToPatternCompilerTest.ts
+++ b/test/unit/IntermediateToPatternCompilerTest.ts
@@ -8,26 +8,30 @@
  */
 
 import { expect } from 'chai';
-import sinon = require('sinon');
-import { Context } from '../../src/spec/intermediateToPattern';
-import { DEFAULT_FLAGS } from '../../src/Parser';
 import IntermediateRepresentation from '../../src/IntermediateRepresentation';
 import IntermediateToPatternCompiler from '../../src/IntermediateToPatternCompiler';
-import PatternFactory from '../../src/PatternFactory';
 import Pattern from '../../src/Pattern';
+import PatternFactory from '../../src/PatternFactory';
+import PatternFragment from '../../src/Match/Fragment/PatternFragment';
 import { SinonStub, SinonStubbedInstance } from 'sinon';
+import sinon = require('sinon');
+import { Flags } from '../../src/declarations/types';
 
 describe('IntermediateToPatternCompiler', () => {
     let compiler: IntermediateToPatternCompiler;
+    let flags: Flags;
     let intermediateToPatternTranspiler: any;
     let ir: SinonStubbedInstance<IntermediateRepresentation> &
         IntermediateRepresentation;
     let pattern: SinonStubbedInstance<Pattern> & Pattern;
     let patternFactory: SinonStubbedInstance<PatternFactory> & PatternFactory;
+    let patternFragment: SinonStubbedInstance<PatternFragment> &
+        PatternFragment;
     let transpile: SinonStub;
     let transpilerIr: object;
 
     beforeEach(() => {
+        flags = { extended: true, caseless: false };
         transpile = sinon.stub();
         intermediateToPatternTranspiler = {
             transpile,
@@ -42,16 +46,23 @@ describe('IntermediateToPatternCompiler', () => {
         patternFactory = sinon.createStubInstance(
             PatternFactory
         ) as SinonStubbedInstance<PatternFactory> & PatternFactory;
+        patternFragment = sinon.createStubInstance(
+            PatternFragment
+        ) as SinonStubbedInstance<PatternFragment> & PatternFragment;
         transpilerIr = {
             'name': 'I_PATTERN',
             'components': [],
         };
 
-        ir.getFlags.returns(DEFAULT_FLAGS);
+        ir.getFlags.returns(flags);
         ir.getTranspilerRepresentation.returns(transpilerIr);
         patternFactory.createPattern.returns(pattern);
 
-        transpile.withArgs(transpilerIr).returns('hello');
+        transpile
+            .withArgs(transpilerIr, {
+                flags,
+            })
+            .returns(patternFragment);
 
         compiler = new IntermediateToPatternCompiler(
             patternFactory,
@@ -60,52 +71,13 @@ describe('IntermediateToPatternCompiler', () => {
     });
 
     describe('compile()', () => {
-        it('should return a correctly constructed Pattern for a simple literal pattern with no flags', () => {
+        it('should return a correctly constructed Pattern for a simple literal pattern with flags', () => {
             expect(compiler.compile(ir)).to.equal(pattern);
             expect(patternFactory.createPattern).to.have.been.calledOnce;
-            expect(String(patternFactory.createPattern.args[0][0])).to.equal(
-                '/hello/dg'
+            expect(patternFactory.createPattern).to.have.been.calledWith(
+                sinon.match.same(patternFragment),
+                flags
             );
-            // capturingGroupNames should only include the entire match group (0).
-            expect(patternFactory.createPattern.args[0][1]).to.deep.equal([0]);
-            // patternToEmulatedNumberedGroupIndex should only include the entire match group (0).
-            expect(patternFactory.createPattern.args[0][2]).to.deep.equal([0]);
-        });
-
-        it('should return a correctly constructed Pattern for a complex pattern with flags', () => {
-            ir.getFlags.returns({ multiline: true });
-            transpile
-                .withArgs(transpilerIr)
-                .callsFake((transpilerIr, context: Context) => {
-                    context.addNumberedCapturingGroup();
-                    context.addAtomicGroup();
-                    context.addNumberedCapturingGroup();
-                    context.addNamedCapturingGroup('gr');
-
-                    return '(?!(a){4,})(b)(?<gr>c)';
-                });
-
-            expect(compiler.compile(ir)).to.equal(pattern);
-            expect(patternFactory.createPattern).to.have.been.calledOnce;
-            expect(String(patternFactory.createPattern.args[0][0])).to.equal(
-                '/(?!(a){4,})(b)(?<gr>c)/dgm'
-            );
-            // capturingGroupNames should only include the entire match group (0).
-            expect(patternFactory.createPattern.args[0][1]).to.deep.equal([
-                0,
-                1,
-                2,
-                'gr',
-                3,
-            ]);
-            // patternToEmulatedNumberedGroupIndex should only include the entire match group (0).
-            expect(patternFactory.createPattern.args[0][2]).to.deep.equal([
-                0, 1,
-                // Note 2 is skipped as it is an emulation capturing group only used
-                // via a backreference to emulate atomic matching.
-                3,
-                4,
-            ]);
         });
     });
 });

--- a/test/unit/Match/Fragment/AlternationFragmentTest.ts
+++ b/test/unit/Match/Fragment/AlternationFragmentTest.ts
@@ -1,0 +1,133 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import { expect } from 'chai';
+import AlternationFragment from '../../../../src/Match/Fragment/AlternationFragment';
+import AlternativeFragment from '../../../../src/Match/Fragment/AlternativeFragment';
+import FragmentMatcher from '../../../../src/Match/FragmentMatcher';
+import LiteralFragment from '../../../../src/Match/Fragment/LiteralFragment';
+
+describe('AlternationFragment', () => {
+    let fragment: AlternationFragment;
+    let fragmentMatcher: FragmentMatcher;
+
+    beforeEach(() => {
+        fragmentMatcher = new FragmentMatcher();
+
+        fragment = new AlternationFragment([
+            new AlternativeFragment(fragmentMatcher, [
+                new LiteralFragment('my'),
+            ]),
+            new AlternativeFragment(fragmentMatcher, [
+                new LiteralFragment('your'),
+            ]),
+            new AlternativeFragment(fragmentMatcher, [
+                new LiteralFragment('my-literal'),
+            ]),
+        ]);
+    });
+
+    describe('match()', () => {
+        describe('when un-anchored', () => {
+            it('should match when the first alternative appears at the start position', () => {
+                const match = fragment.match('here is my-literal', 8, false);
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('my');
+                expect(match?.getStart()).to.equal(8);
+            });
+
+            it('should match when the second alternative appears at the start position', () => {
+                const match = fragment.match('here is your-literal', 8, false);
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('your');
+                expect(match?.getStart()).to.equal(8);
+            });
+
+            it('should match when the first alternative appears after the start position', () => {
+                const match = fragment.match('here is my-literal', 5, false);
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('my');
+                expect(match?.getStart()).to.equal(8);
+            });
+
+            it('should return null when no alternative appears in the subject', () => {
+                expect(fragment.match('something-else', 0, false)).to.be.null;
+            });
+
+            it('should return null when the only matching alternative appears before the start position', () => {
+                expect(fragment.match('here is my-literal', 9, false)).to.be
+                    .null;
+            });
+        });
+
+        describe('when anchored', () => {
+            it('should match when the first alternative appears at the start position', () => {
+                const match = fragment.match('here is my-literal', 8, true);
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('my');
+                expect(match?.getStart()).to.equal(8);
+            });
+
+            it('should match when the second alternative appears at the start position', () => {
+                const match = fragment.match('here is your-literal', 8, true);
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('your');
+                expect(match?.getStart()).to.equal(8);
+            });
+
+            it('should return null when the first alternative appears after the start position', () => {
+                const match = fragment.match('here is my-literal', 5, true);
+
+                expect(match).to.be.null;
+            });
+
+            it('should return null when no alternative appears in the subject', () => {
+                expect(fragment.match('something-else', 0, true)).to.be.null;
+            });
+
+            it('should return null when the only matching alternative appears before the start position', () => {
+                expect(fragment.match('here is my-literal', 9, true)).to.be
+                    .null;
+            });
+        });
+    });
+
+    describe('toString()', () => {
+        it('should return the correct string representation', () => {
+            expect(fragment.toString()).to.equal('my|your|my-literal');
+        });
+    });
+
+    describe('toStructure()', () => {
+        it('should return the correct structure', () => {
+            expect(fragment.toStructure()).to.deep.equal({
+                type: 'alternation',
+                alternatives: [
+                    {
+                        type: 'alternative',
+                        components: [{ type: 'literal', chars: 'my' }],
+                    },
+                    {
+                        type: 'alternative',
+                        components: [{ type: 'literal', chars: 'your' }],
+                    },
+                    {
+                        type: 'alternative',
+                        components: [{ type: 'literal', chars: 'my-literal' }],
+                    },
+                ],
+            });
+        });
+    });
+});

--- a/test/unit/Match/Fragment/CapturingGroupFragmentTest.ts
+++ b/test/unit/Match/Fragment/CapturingGroupFragmentTest.ts
@@ -1,0 +1,129 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import { expect } from 'chai';
+import CapturingGroupFragment from '../../../../src/Match/Fragment/CapturingGroupFragment';
+import FragmentMatcher from '../../../../src/Match/FragmentMatcher';
+import LiteralFragment from '../../../../src/Match/Fragment/LiteralFragment';
+
+describe('CapturingGroupFragment', () => {
+    let fragment: CapturingGroupFragment;
+    let fragmentMatcher: FragmentMatcher;
+
+    beforeEach(() => {
+        fragmentMatcher = new FragmentMatcher();
+
+        fragment = new CapturingGroupFragment(
+            fragmentMatcher,
+            [new LiteralFragment('my-'), new LiteralFragment('text')],
+            7
+        );
+    });
+
+    describe('match()', () => {
+        describe('when un-anchored', () => {
+            it('should match when the group appears at the start position', () => {
+                const match = fragment.match('here is my-text', 8, false);
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('my-text');
+                expect(match?.getStart()).to.equal(8);
+                expect(match?.getNamedCaptures()).to.deep.equal({});
+                expect(match?.getNamedCaptureIndices()).to.deep.equal({});
+                expect(match?.getNumberedCaptures()).to.deep.equal({
+                    7: 'my-text',
+                });
+                expect(match?.getNumberedCaptureIndices()).to.deep.equal({
+                    7: [8, 15],
+                });
+            });
+
+            it('should match when the group appears after the start position', () => {
+                const match = fragment.match('here is my-text', 5, false);
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('my-text');
+                expect(match?.getStart()).to.equal(8);
+                expect(match?.getNamedCaptures()).to.deep.equal({});
+                expect(match?.getNamedCaptureIndices()).to.deep.equal({});
+                expect(match?.getNumberedCaptures()).to.deep.equal({
+                    7: 'my-text',
+                });
+                expect(match?.getNumberedCaptureIndices()).to.deep.equal({
+                    7: [8, 15],
+                });
+            });
+
+            it('should return null when the group does not appear in the subject', () => {
+                expect(fragment.match('something-else', 0, false)).to.be.null;
+            });
+
+            it('should return null when the only match appears before the start position', () => {
+                expect(fragment.match('here is my-text', 9, false)).to.be.null;
+            });
+        });
+
+        describe('when anchored', () => {
+            it('should match when the group appears at the start position', () => {
+                const match = fragment.match('here is my-text', 8, true);
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('my-text');
+                expect(match?.getStart()).to.equal(8);
+                expect(match?.getNamedCaptures()).to.deep.equal({});
+                expect(match?.getNamedCaptureIndices()).to.deep.equal({});
+                expect(match?.getNumberedCaptures()).to.deep.equal({
+                    7: 'my-text',
+                });
+                expect(match?.getNumberedCaptureIndices()).to.deep.equal({
+                    7: [8, 15],
+                });
+            });
+
+            it('should return null when the group appears after the start position', () => {
+                const match = fragment.match('here is my-text', 5, true);
+
+                expect(match).to.be.null;
+            });
+
+            it('should return null when the group does not appear in the subject', () => {
+                expect(fragment.match('something-else', 0, true)).to.be.null;
+            });
+
+            it('should return null when the only match appears before the start position', () => {
+                expect(fragment.match('here is my-text', 9, true)).to.be.null;
+            });
+        });
+    });
+
+    describe('toString()', () => {
+        it('should return the correct string representation', () => {
+            expect(fragment.toString()).to.equal('(my-text)');
+        });
+    });
+
+    describe('toStructure()', () => {
+        it('should return the correct structure', () => {
+            expect(fragment.toStructure()).to.deep.equal({
+                type: 'capturing-group',
+                groupIndex: 7,
+                components: [
+                    {
+                        type: 'literal',
+                        chars: 'my-',
+                    },
+                    {
+                        type: 'literal',
+                        chars: 'text',
+                    },
+                ],
+            });
+        });
+    });
+});

--- a/test/unit/Match/Fragment/LiteralFragmentTest.ts
+++ b/test/unit/Match/Fragment/LiteralFragmentTest.ts
@@ -1,0 +1,88 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import { expect } from 'chai';
+import LiteralFragment from '../../../../src/Match/Fragment/LiteralFragment';
+
+describe('LiteralFragment', () => {
+    let fragment: LiteralFragment;
+
+    beforeEach(() => {
+        fragment = new LiteralFragment('my-literal');
+    });
+
+    describe('match()', () => {
+        describe('when un-anchored', () => {
+            it('should match when the literal appears at the start position', () => {
+                const match = fragment.match('here is my-literal', 8, false);
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('my-literal');
+                expect(match?.getStart()).to.equal(8);
+            });
+
+            it('should match when the literal appears after the start position', () => {
+                const match = fragment.match('here is my-literal', 5, false);
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('my-literal');
+                expect(match?.getStart()).to.equal(8);
+            });
+
+            it('should return null when the literal does not appear in subject', () => {
+                expect(fragment.match('something-else', 0, false)).to.be.null;
+            });
+
+            it('should return null when the literal appears before the start position', () => {
+                expect(fragment.match('here is my-literal', 9, false)).to.be
+                    .null;
+            });
+        });
+
+        describe('when anchored', () => {
+            it('should match when the literal appears at the start position', () => {
+                const match = fragment.match('here is my-literal', 8, true);
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('my-literal');
+                expect(match?.getStart()).to.equal(8);
+            });
+
+            it('should return null when the literal appears after the start position', () => {
+                const match = fragment.match('here is my-literal', 5, true);
+
+                expect(match).to.be.null;
+            });
+
+            it('should return null when the literal does not appear in subject', () => {
+                expect(fragment.match('something-else', 0, true)).to.be.null;
+            });
+
+            it('should return null when the literal appears before the start position', () => {
+                expect(fragment.match('here is my-literal', 9, true)).to.be
+                    .null;
+            });
+        });
+    });
+
+    describe('toString()', () => {
+        it('should return the chars', () => {
+            expect(fragment.toString()).to.equal('my-literal');
+        });
+    });
+
+    describe('toStructure()', () => {
+        it('should return the correct structure', () => {
+            expect(fragment.toStructure()).to.deep.equal({
+                type: 'literal',
+                chars: 'my-literal',
+            });
+        });
+    });
+});

--- a/test/unit/Match/Fragment/MinimisingQuantifierFragmentTest.ts
+++ b/test/unit/Match/Fragment/MinimisingQuantifierFragmentTest.ts
@@ -1,0 +1,263 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import { expect } from 'chai';
+import CapturingGroupFragment from '../../../../src/Match/Fragment/CapturingGroupFragment';
+import FragmentMatcher from '../../../../src/Match/FragmentMatcher';
+import LiteralFragment from '../../../../src/Match/Fragment/LiteralFragment';
+import MinimisingQuantifierFragment from '../../../../src/Match/Fragment/MinimisingQuantifierFragment';
+import NativeFragment from '../../../../src/Match/Fragment/NativeFragment';
+import QuantifierMatcher from '../../../../src/Match/QuantifierMatcher';
+
+describe('MinimisingQuantifierFragment', () => {
+    let fragment: MinimisingQuantifierFragment;
+    let fragmentMatcher: FragmentMatcher;
+    let quantifierMatcher: QuantifierMatcher;
+
+    beforeEach(() => {
+        fragmentMatcher = new FragmentMatcher();
+        quantifierMatcher = new QuantifierMatcher(fragmentMatcher);
+
+        fragment = new MinimisingQuantifierFragment(
+            fragmentMatcher,
+            quantifierMatcher,
+            new LiteralFragment('my-text'),
+            2,
+            4
+        );
+    });
+
+    describe('match()', () => {
+        describe('when un-anchored', () => {
+            it('should not match when the component appears at the start position once', () => {
+                const match = fragment.match('here is my-text', 8, false);
+
+                expect(match).to.be.null;
+            });
+
+            it('should match when the component appears at the start position twice consecutively', () => {
+                const match = fragment.match(
+                    'here is my-textmy-text',
+                    8,
+                    false
+                );
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('my-textmy-text');
+                expect(match?.getStart()).to.equal(8);
+            });
+
+            it('should match when the component appears at the start position twice consecutively after the start position', () => {
+                const match = fragment.match(
+                    'here is my-textmy-text',
+                    5,
+                    false
+                );
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('my-textmy-text');
+                expect(match?.getStart()).to.equal(8);
+            });
+
+            it('should not include a third occurrence in the match initially', () => {
+                const match = fragment.match(
+                    'here is my-textmy-textmy-text',
+                    8,
+                    false
+                );
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal(
+                    // Only the first two (up to minimumMatches) are matched.
+                    'my-textmy-text'
+                );
+                expect(match?.getStart()).to.equal(8);
+            });
+
+            it('should backtrack inside the most recent occurrence while there are at least the minimum number of matches', () => {
+                fragment = new MinimisingQuantifierFragment(
+                    fragmentMatcher,
+                    quantifierMatcher,
+                    new CapturingGroupFragment(
+                        fragmentMatcher,
+                        [new NativeFragment('my(?:-text)?')],
+                        12
+                    ),
+                    2,
+                    4
+                );
+
+                const match = fragment.match(
+                    'here is my-textmy-text',
+                    8,
+                    false
+                );
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('my-textmy-text');
+                const backtrackedMatch = match?.backtrack();
+                expect(backtrackedMatch?.getCapture()).to.equal('my-textmy');
+            });
+
+            it('should capture the next on backtrack while there are less than the maximum number of matches to capture', () => {
+                const match = fragment.match(
+                    'here is my-textmy-textmy-text',
+                    8,
+                    false
+                );
+
+                expect(match).not.to.be.null;
+                const backtrackedMatch = match?.backtrack();
+                expect(backtrackedMatch?.getCapture()).to.equal(
+                    'my-textmy-textmy-text'
+                );
+            });
+
+            it('should fail to backtrack when the maximum has been reached', () => {
+                const match = fragment.match(
+                    'here is my-textmy-textmy-textmy-textmy-text',
+                    8,
+                    false
+                );
+
+                expect(match).not.to.be.null;
+                const backtrackedMatch = match
+                    ?.backtrack()
+                    ?.backtrack()
+                    ?.backtrack(); // Backtrack three times - the third should fail to match.
+                expect(backtrackedMatch).to.be.null;
+            });
+
+            it('should return null when the component does not appear in the subject', () => {
+                expect(fragment.match('something-else', 0, false)).to.be.null;
+            });
+
+            it('should return null when the only match appears before the start position', () => {
+                expect(fragment.match('here is my-textmy-text', 9, false)).to.be
+                    .null;
+            });
+        });
+
+        describe('when anchored', () => {
+            it('should not match when the component appears at the start position once', () => {
+                const match = fragment.match('here is my-text', 8, true);
+
+                expect(match).to.be.null;
+            });
+
+            it('should match when the component appears at the start position twice consecutively', () => {
+                const match = fragment.match('here is my-textmy-text', 8, true);
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('my-textmy-text');
+                expect(match?.getStart()).to.equal(8);
+            });
+
+            it('should return null when the component appears at the start position twice consecutively after the start position', () => {
+                const match = fragment.match('here is my-textmy-text', 5, true);
+
+                expect(match).to.be.null;
+            });
+
+            it('should not include a third occurrence in the match initially', () => {
+                const match = fragment.match(
+                    'here is my-textmy-textmy-text',
+                    8,
+                    true
+                );
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal(
+                    // Only the first two (up to minimumMatches) are matched.
+                    'my-textmy-text'
+                );
+                expect(match?.getStart()).to.equal(8);
+            });
+
+            it('should backtrack inside the most recent occurrence while there are at least the minimum number of matches', () => {
+                fragment = new MinimisingQuantifierFragment(
+                    fragmentMatcher,
+                    quantifierMatcher,
+                    new CapturingGroupFragment(
+                        fragmentMatcher,
+                        [new NativeFragment('my(?:-text)?')],
+                        12
+                    ),
+                    2,
+                    4
+                );
+
+                const match = fragment.match('here is my-textmy-text', 8, true);
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('my-textmy-text');
+                const backtrackedMatch = match?.backtrack();
+                expect(backtrackedMatch?.getCapture()).to.equal('my-textmy');
+            });
+
+            it('should capture the next on backtrack while there are less than the maximum number of matches to capture', () => {
+                const match = fragment.match(
+                    'here is my-textmy-textmy-text',
+                    8,
+                    true
+                );
+
+                expect(match).not.to.be.null;
+                const backtrackedMatch = match?.backtrack();
+                expect(backtrackedMatch?.getCapture()).to.equal(
+                    'my-textmy-textmy-text'
+                );
+            });
+
+            it('should fail to backtrack when the maximum has been reached', () => {
+                const match = fragment.match(
+                    'here is my-textmy-textmy-textmy-textmy-text',
+                    8,
+                    true
+                );
+
+                expect(match).not.to.be.null;
+                const backtrackedMatch = match
+                    ?.backtrack()
+                    ?.backtrack()
+                    ?.backtrack(); // Backtrack three times - the third should fail to match.
+                expect(backtrackedMatch).to.be.null;
+            });
+
+            it('should return null when the component does not appear in the subject', () => {
+                expect(fragment.match('something-else', 0, true)).to.be.null;
+            });
+
+            it('should return null when the only match appears before the start position', () => {
+                expect(fragment.match('here is my-textmy-text', 9, true)).to.be
+                    .null;
+            });
+        });
+    });
+
+    describe('toString()', () => {
+        it('should return the correct string representation', () => {
+            expect(fragment.toString()).to.equal('my-text{2,4}?');
+        });
+    });
+
+    describe('toStructure()', () => {
+        it('should return the correct structure', () => {
+            expect(fragment.toStructure()).to.deep.equal({
+                type: 'minimising-quantifier',
+                minimumMatches: 2,
+                maximumMatches: 4,
+                component: {
+                    type: 'literal',
+                    chars: 'my-text',
+                },
+            });
+        });
+    });
+});

--- a/test/unit/Match/Fragment/NamedCapturingGroupFragmentTest.ts
+++ b/test/unit/Match/Fragment/NamedCapturingGroupFragmentTest.ts
@@ -1,0 +1,143 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import { expect } from 'chai';
+import FragmentMatcher from '../../../../src/Match/FragmentMatcher';
+import LiteralFragment from '../../../../src/Match/Fragment/LiteralFragment';
+import NamedCapturingGroupFragment from '../../../../src/Match/Fragment/NamedCapturingGroupFragment';
+
+describe('NamedCapturingGroupFragment', () => {
+    let fragment: NamedCapturingGroupFragment;
+    let fragmentMatcher: FragmentMatcher;
+
+    beforeEach(() => {
+        fragmentMatcher = new FragmentMatcher();
+
+        fragment = new NamedCapturingGroupFragment(
+            fragmentMatcher,
+            [new LiteralFragment('my-'), new LiteralFragment('text')],
+            7,
+            'myGroup'
+        );
+    });
+
+    describe('match()', () => {
+        describe('when un-anchored', () => {
+            it('should match when the group appears at the start position', () => {
+                const match = fragment.match('here is my-text', 8, false);
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('my-text');
+                expect(match?.getStart()).to.equal(8);
+                expect(match?.getNamedCaptures()).to.deep.equal({
+                    'myGroup': 'my-text',
+                });
+                expect(match?.getNamedCaptureIndices()).to.deep.equal({
+                    'myGroup': [8, 15],
+                });
+                expect(match?.getNumberedCaptures()).to.deep.equal({
+                    7: 'my-text',
+                });
+                expect(match?.getNumberedCaptureIndices()).to.deep.equal({
+                    7: [8, 15],
+                });
+            });
+
+            it('should match when the group appears after the start position', () => {
+                const match = fragment.match('here is my-text', 5, false);
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('my-text');
+                expect(match?.getStart()).to.equal(8);
+                expect(match?.getNamedCaptures()).to.deep.equal({
+                    'myGroup': 'my-text',
+                });
+                expect(match?.getNamedCaptureIndices()).to.deep.equal({
+                    'myGroup': [8, 15],
+                });
+                expect(match?.getNumberedCaptures()).to.deep.equal({
+                    7: 'my-text',
+                });
+                expect(match?.getNumberedCaptureIndices()).to.deep.equal({
+                    7: [8, 15],
+                });
+            });
+
+            it('should return null when the group does not appear in the subject', () => {
+                expect(fragment.match('something-else', 0, false)).to.be.null;
+            });
+
+            it('should return null when the only match appears before the start position', () => {
+                expect(fragment.match('here is my-text', 9, false)).to.be.null;
+            });
+        });
+
+        describe('when anchored', () => {
+            it('should match when the group appears at the start position', () => {
+                const match = fragment.match('here is my-text', 8, true);
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('my-text');
+                expect(match?.getStart()).to.equal(8);
+                expect(match?.getNamedCaptures()).to.deep.equal({
+                    'myGroup': 'my-text',
+                });
+                expect(match?.getNamedCaptureIndices()).to.deep.equal({
+                    'myGroup': [8, 15],
+                });
+                expect(match?.getNumberedCaptures()).to.deep.equal({
+                    7: 'my-text',
+                });
+                expect(match?.getNumberedCaptureIndices()).to.deep.equal({
+                    7: [8, 15],
+                });
+            });
+
+            it('should return null when the group appears after the start position', () => {
+                const match = fragment.match('here is my-text', 5, true);
+
+                expect(match).to.be.null;
+            });
+
+            it('should return null when the group does not appear in the subject', () => {
+                expect(fragment.match('something-else', 0, true)).to.be.null;
+            });
+
+            it('should return null when the only match appears before the start position', () => {
+                expect(fragment.match('here is my-text', 9, true)).to.be.null;
+            });
+        });
+    });
+
+    describe('toString()', () => {
+        it('should return the correct string representation', () => {
+            expect(fragment.toString()).to.equal('(?<myGroup>my-text)');
+        });
+    });
+
+    describe('toStructure()', () => {
+        it('should return the correct structure', () => {
+            expect(fragment.toStructure()).to.deep.equal({
+                type: 'named-capturing-group',
+                groupIndex: 7,
+                groupName: 'myGroup',
+                components: [
+                    {
+                        type: 'literal',
+                        chars: 'my-',
+                    },
+                    {
+                        type: 'literal',
+                        chars: 'text',
+                    },
+                ],
+            });
+        });
+    });
+});

--- a/test/unit/Match/Fragment/NativeFragmentTest.ts
+++ b/test/unit/Match/Fragment/NativeFragmentTest.ts
@@ -1,0 +1,433 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import { expect } from 'chai';
+import NativeFragment from '../../../../src/Match/Fragment/NativeFragment';
+
+describe('NativeFragment', () => {
+    let fragment: NativeFragment;
+
+    beforeEach(() => {
+        fragment = new NativeFragment('(is )my(?<myGroup>.*)text', {
+            7: 1,
+            12: 2,
+        });
+    });
+
+    describe('match()', () => {
+        describe('when un-anchored', () => {
+            it('should match when the pattern appears at the start position', () => {
+                const match = fragment.match(
+                    'here is my-literal-text',
+                    5,
+                    false
+                );
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('is my-literal-text');
+                expect(match?.getStart()).to.equal(5);
+                expect(match?.getNamedCaptures()).to.deep.equal({
+                    'myGroup': '-literal-',
+                });
+                expect(match?.getNumberedCaptures()).to.deep.equal({
+                    // Note the numbered matches have been mapped accordingly.
+                    7: 'is ',
+                    12: '-literal-',
+                });
+            });
+
+            it('should match when the pattern appears after the start position', () => {
+                const match = fragment.match(
+                    'here is my-literal-text',
+                    3,
+                    false
+                );
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('is my-literal-text');
+                expect(match?.getStart()).to.equal(5);
+                expect(match?.getNamedCaptures()).to.deep.equal({
+                    'myGroup': '-literal-',
+                });
+                expect(match?.getNumberedCaptures()).to.deep.equal({
+                    7: 'is ',
+                    12: '-literal-',
+                });
+            });
+
+            it('should backtrack a native maximising (greedy) match backwards', () => {
+                const match = fragment.match(
+                    'here is my-literal-with-text-then-text',
+                    3,
+                    false
+                );
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal(
+                    'is my-literal-with-text-then-text'
+                );
+                expect(match?.getStart()).to.equal(5);
+                expect(match?.getNamedCaptures()).to.deep.equal({
+                    'myGroup': '-literal-with-text-then-',
+                });
+                expect(match?.getNumberedCaptures()).to.deep.equal({
+                    7: 'is ',
+                    12: '-literal-with-text-then-',
+                });
+                const backtrackedMatch = match?.backtrack();
+                expect(backtrackedMatch?.getCapture()).to.equal(
+                    'is my-literal-with-text'
+                );
+                expect(backtrackedMatch?.getStart()).to.equal(5);
+                expect(backtrackedMatch?.getNamedCaptures()).to.deep.equal({
+                    'myGroup': '-literal-with-',
+                });
+                expect(backtrackedMatch?.getNumberedCaptures()).to.deep.equal({
+                    7: 'is ',
+                    12: '-literal-with-',
+                });
+                expect(backtrackedMatch?.backtrack()).to.be.null;
+            });
+
+            it('should backtrack a native minimising (lazy) match forwards', () => {
+                fragment = new NativeFragment('(is )my(?<myGroup>.*?)text', {
+                    7: 1,
+                    12: 2,
+                });
+                const match = fragment.match(
+                    'here is my-literal-with-text-then-text',
+                    3,
+                    false
+                );
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('is my-literal-with-text');
+                expect(match?.getStart()).to.equal(5);
+                expect(match?.getNamedCaptures()).to.deep.equal({
+                    'myGroup': '-literal-with-',
+                });
+                expect(match?.getNumberedCaptures()).to.deep.equal({
+                    7: 'is ',
+                    12: '-literal-with-',
+                });
+                const backtrackedMatch = match?.backtrack();
+                expect(backtrackedMatch?.getCapture()).to.equal(
+                    'is my-literal-with-text-then-text'
+                );
+                expect(backtrackedMatch?.getStart()).to.equal(5);
+                expect(backtrackedMatch?.getNamedCaptures()).to.deep.equal({
+                    'myGroup': '-literal-with-text-then-',
+                });
+                expect(backtrackedMatch?.getNumberedCaptures()).to.deep.equal({
+                    7: 'is ',
+                    12: '-literal-with-text-then-',
+                });
+                expect(backtrackedMatch?.backtrack()).to.be.null;
+            });
+
+            it('should return null when the pattern does not appear in subject', () => {
+                expect(fragment.match('something-else', 0, false)).to.be.null;
+            });
+
+            it('should return null when the pattern appears before the start position', () => {
+                expect(fragment.match('here is my-literal-text', 6, false)).to
+                    .be.null;
+            });
+        });
+
+        describe('when anchored', () => {
+            it('should match when the pattern appears at the start position', () => {
+                const match = fragment.match(
+                    'here is my-literal-text',
+                    5,
+                    true
+                );
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('is my-literal-text');
+                expect(match?.getStart()).to.equal(5);
+                expect(match?.getNamedCaptures()).to.deep.equal({
+                    'myGroup': '-literal-',
+                });
+                expect(match?.getNumberedCaptures()).to.deep.equal({
+                    // Note the numbered matches have been mapped accordingly.
+                    7: 'is ',
+                    12: '-literal-',
+                });
+            });
+
+            it('should return null when the pattern appears after the start position', () => {
+                const match = fragment.match(
+                    'here is my-literal-text',
+                    3,
+                    true
+                );
+
+                expect(match).to.be.null;
+            });
+
+            it('should backtrack a native maximising (greedy) match backwards', () => {
+                const match = fragment.match(
+                    'here is my-literal-with-text-then-text',
+                    5,
+                    true
+                );
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal(
+                    'is my-literal-with-text-then-text'
+                );
+                expect(match?.getStart()).to.equal(5);
+                expect(match?.getNamedCaptures()).to.deep.equal({
+                    'myGroup': '-literal-with-text-then-',
+                });
+                expect(match?.getNumberedCaptures()).to.deep.equal({
+                    7: 'is ',
+                    12: '-literal-with-text-then-',
+                });
+                const backtrackedMatch = match?.backtrack();
+                expect(backtrackedMatch?.getCapture()).to.equal(
+                    'is my-literal-with-text'
+                );
+                expect(backtrackedMatch?.getStart()).to.equal(5);
+                expect(backtrackedMatch?.getNamedCaptures()).to.deep.equal({
+                    'myGroup': '-literal-with-',
+                });
+                expect(backtrackedMatch?.getNumberedCaptures()).to.deep.equal({
+                    7: 'is ',
+                    12: '-literal-with-',
+                });
+                expect(backtrackedMatch?.backtrack()).to.be.null;
+            });
+
+            it('should backtrack a native minimising (lazy) match forwards', () => {
+                fragment = new NativeFragment('(is )my(?<myGroup>.*?)text', {
+                    7: 1,
+                    12: 2,
+                });
+                const match = fragment.match(
+                    'here is my-literal-with-text-then-text',
+                    5,
+                    true
+                );
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('is my-literal-with-text');
+                expect(match?.getStart()).to.equal(5);
+                expect(match?.getNamedCaptures()).to.deep.equal({
+                    'myGroup': '-literal-with-',
+                });
+                expect(match?.getNumberedCaptures()).to.deep.equal({
+                    7: 'is ',
+                    12: '-literal-with-',
+                });
+                const backtrackedMatch = match?.backtrack();
+                expect(backtrackedMatch?.getCapture()).to.equal(
+                    'is my-literal-with-text-then-text'
+                );
+                expect(backtrackedMatch?.getStart()).to.equal(5);
+                expect(backtrackedMatch?.getNamedCaptures()).to.deep.equal({
+                    'myGroup': '-literal-with-text-then-',
+                });
+                expect(backtrackedMatch?.getNumberedCaptures()).to.deep.equal({
+                    7: 'is ',
+                    12: '-literal-with-text-then-',
+                });
+                expect(backtrackedMatch?.backtrack()).to.be.null;
+            });
+
+            it('should return null when the pattern does not appear in subject', () => {
+                expect(fragment.match('something-else', 0, true)).to.be.null;
+            });
+
+            it('should return null when the pattern appears before the start position', () => {
+                expect(fragment.match('here is my-literal-text', 6, true)).to.be
+                    .null;
+            });
+        });
+
+        describe('caseless mode', () => {
+            it('should match case-sensitively outside caseless mode', () => {
+                expect(fragment.match('here is MY-literal-text', 0, false)).to
+                    .be.null;
+            });
+
+            it('should match case-insensitively in caseless mode', () => {
+                fragment = new NativeFragment(
+                    '(is )my(?<myGroup>.*)text',
+                    {
+                        7: 1,
+                        12: 2,
+                    },
+                    { caseless: true }
+                );
+
+                const match = fragment.match(
+                    'here is MY-literal-text',
+                    0,
+                    false
+                );
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('is MY-literal-text');
+                expect(match?.getStart()).to.equal(5);
+            });
+        });
+
+        describe('multiline mode', () => {
+            it('should not match ^ and $ as start- and end-of-line assertions outside multiline mode', () => {
+                fragment = new NativeFragment(
+                    '^my(.*)text$',
+                    {
+                        9: 1,
+                    },
+                    { multiline: false }
+                );
+
+                const match = fragment.match(
+                    'here is\nmy multiline text\nthe end',
+                    0,
+                    false
+                );
+
+                expect(match).to.be.null;
+            });
+
+            describe('in multiline mode', () => {
+                beforeEach(() => {
+                    fragment = new NativeFragment(
+                        '^my([\\s\\S]*)text$',
+                        {
+                            9: 1,
+                        },
+                        { multiline: true }
+                    );
+                });
+
+                it('should match ^ and $ as start- and end-of-line assertions', () => {
+                    const match = fragment.match(
+                        'here is\nmy multiline text\nthe end',
+                        0,
+                        false
+                    );
+
+                    expect(match).not.to.be.null;
+                    expect(match?.getCapture()).to.equal('my multiline text');
+                    expect(match?.getStart()).to.equal(8);
+                    expect(match?.getNamedCaptures()).to.deep.equal({});
+                    expect(match?.getNumberedCaptures()).to.deep.equal({
+                        9: ' multiline ',
+                    });
+                });
+
+                it('should be able to backtrack across newlines', () => {
+                    const match = fragment.match(
+                        'here is\nmy multiline text\nand more text\nthe end',
+                        0,
+                        false
+                    );
+
+                    expect(match).not.to.be.null;
+                    expect(match?.getCapture()).to.equal(
+                        'my multiline text\nand more text'
+                    );
+                    expect(match?.getStart()).to.equal(8);
+                    expect(match?.getNamedCaptures()).to.deep.equal({});
+                    expect(match?.getNumberedCaptures()).to.deep.equal({
+                        9: ' multiline text\nand more ',
+                    });
+                    const backtrackedMatch = match?.backtrack();
+                    expect(backtrackedMatch?.getCapture()).to.equal(
+                        'my multiline text'
+                    );
+                    expect(backtrackedMatch?.getStart()).to.equal(8);
+                    expect(backtrackedMatch?.getNamedCaptures()).to.deep.equal(
+                        {}
+                    );
+                    expect(
+                        backtrackedMatch?.getNumberedCaptures()
+                    ).to.deep.equal({
+                        9: ' multiline ',
+                    });
+                });
+            });
+        });
+
+        describe('dot (all) mode', () => {
+            it('should not match dot against newlines outside dot (all) mode', () => {
+                fragment = new NativeFragment(
+                    '(is )my(?<myGroup>.*)text',
+                    {
+                        7: 1,
+                        12: 2,
+                    },
+                    {
+                        dotAll: false,
+                    }
+                );
+
+                expect(fragment.match('here is my-lit\neral-text', 0, false)).to
+                    .be.null;
+            });
+
+            describe('in dot (all) mode', () => {
+                it('should match dot against newlines', () => {
+                    fragment = new NativeFragment(
+                        '(is )my(?<myGroup>.*)text',
+                        {
+                            7: 1,
+                            12: 2,
+                        },
+                        {
+                            dotAll: true,
+                        }
+                    );
+
+                    const match = fragment.match(
+                        'this is my-lit\neral-text in here',
+                        0,
+                        false
+                    );
+
+                    expect(match).not.to.be.null;
+                    expect(match?.getCapture()).to.equal(
+                        'is my-lit\neral-text'
+                    );
+                    expect(match?.getStart()).to.equal(5);
+                    expect(match?.getNamedCaptures()).to.deep.equal({
+                        'myGroup': '-lit\neral-',
+                    });
+                    expect(match?.getNumberedCaptures()).to.deep.equal({
+                        7: 'is ',
+                        12: '-lit\neral-',
+                    });
+                });
+            });
+        });
+    });
+
+    describe('toString()', () => {
+        it('should return the chars', () => {
+            expect(fragment.toString()).to.equal('(is )my(?<myGroup>.*)text');
+        });
+    });
+
+    describe('toStructure()', () => {
+        it('should return the correct structure', () => {
+            expect(fragment.toStructure()).to.deep.equal({
+                type: 'native',
+                chars: '(is )my(?<myGroup>.*)text',
+                patternToEmulatedNumberedGroupIndex: {
+                    '7': 1,
+                    '12': 2,
+                },
+            });
+        });
+    });
+});

--- a/test/unit/Match/Fragment/NonCapturingGroupFragmentTest.ts
+++ b/test/unit/Match/Fragment/NonCapturingGroupFragmentTest.ts
@@ -1,0 +1,103 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import { expect } from 'chai';
+import FragmentMatcher from '../../../../src/Match/FragmentMatcher';
+import LiteralFragment from '../../../../src/Match/Fragment/LiteralFragment';
+import NonCapturingGroupFragment from '../../../../src/Match/Fragment/NonCapturingGroupFragment';
+
+describe('NonCapturingGroupFragment', () => {
+    let fragment: NonCapturingGroupFragment;
+    let fragmentMatcher: FragmentMatcher;
+
+    beforeEach(() => {
+        fragmentMatcher = new FragmentMatcher();
+
+        fragment = new NonCapturingGroupFragment(fragmentMatcher, [
+            new LiteralFragment('my-'),
+            new LiteralFragment('text'),
+        ]);
+    });
+
+    describe('match()', () => {
+        describe('when un-anchored', () => {
+            it('should match when the group appears at the start position', () => {
+                const match = fragment.match('here is my-text', 8, false);
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('my-text');
+                expect(match?.getStart()).to.equal(8);
+            });
+
+            it('should match when the group appears after the start position', () => {
+                const match = fragment.match('here is my-text', 5, false);
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('my-text');
+                expect(match?.getStart()).to.equal(8);
+            });
+
+            it('should return null when the group does not appear in the subject', () => {
+                expect(fragment.match('something-else', 0, false)).to.be.null;
+            });
+
+            it('should return null when the only match appears before the start position', () => {
+                expect(fragment.match('here is my-text', 9, false)).to.be.null;
+            });
+        });
+
+        describe('when anchored', () => {
+            it('should match when the group appears at the start position', () => {
+                const match = fragment.match('here is my-text', 8, true);
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('my-text');
+                expect(match?.getStart()).to.equal(8);
+            });
+
+            it('should return null when the group appears after the start position', () => {
+                const match = fragment.match('here is my-text', 5, true);
+
+                expect(match).to.be.null;
+            });
+
+            it('should return null when the group does not appear in the subject', () => {
+                expect(fragment.match('something-else', 0, true)).to.be.null;
+            });
+
+            it('should return null when the only match appears before the start position', () => {
+                expect(fragment.match('here is my-text', 9, true)).to.be.null;
+            });
+        });
+    });
+
+    describe('toString()', () => {
+        it('should return the correct string representation', () => {
+            expect(fragment.toString()).to.equal('(?:my-text)');
+        });
+    });
+
+    describe('toStructure()', () => {
+        it('should return the correct structure', () => {
+            expect(fragment.toStructure()).to.deep.equal({
+                type: 'non-capturing-group',
+                components: [
+                    {
+                        type: 'literal',
+                        chars: 'my-',
+                    },
+                    {
+                        type: 'literal',
+                        chars: 'text',
+                    },
+                ],
+            });
+        });
+    });
+});

--- a/test/unit/Match/Fragment/NoopFragmentTest.ts
+++ b/test/unit/Match/Fragment/NoopFragmentTest.ts
@@ -1,0 +1,43 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import { expect } from 'chai';
+import NoopFragment from '../../../../src/Match/Fragment/NoopFragment';
+
+describe('NoopFragment', () => {
+    let fragment: NoopFragment;
+
+    beforeEach(() => {
+        fragment = new NoopFragment();
+    });
+
+    describe('match()', () => {
+        it('should return an empty match', () => {
+            const match = fragment.match('here is my-text', 6);
+
+            expect(match).not.to.be.null;
+            expect(match?.getCapture()).to.equal('');
+            expect(match?.getStart()).to.equal(6);
+        });
+    });
+
+    describe('toString()', () => {
+        it('should return the empty string', () => {
+            expect(fragment.toString()).to.equal('');
+        });
+    });
+
+    describe('toStructure()', () => {
+        it('should return the correct structure', () => {
+            expect(fragment.toStructure()).to.deep.equal({
+                type: 'noop',
+            });
+        });
+    });
+});

--- a/test/unit/Match/Fragment/PatternFragmentTest.ts
+++ b/test/unit/Match/Fragment/PatternFragmentTest.ts
@@ -1,0 +1,129 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import { expect } from 'chai';
+import FragmentMatcher from '../../../../src/Match/FragmentMatcher';
+import LiteralFragment from '../../../../src/Match/Fragment/LiteralFragment';
+import PatternFragment from '../../../../src/Match/Fragment/PatternFragment';
+
+describe('PatternFragment', () => {
+    let fragment: PatternFragment;
+    let fragmentMatcher: FragmentMatcher;
+
+    beforeEach(() => {
+        fragmentMatcher = new FragmentMatcher();
+
+        fragment = new PatternFragment(
+            fragmentMatcher,
+            [new LiteralFragment('my-'), new LiteralFragment('text')],
+            [0, 1, 'myGroup', 2]
+        );
+    });
+
+    describe('match()', () => {
+        describe('when un-anchored', () => {
+            it('should match when the pattern appears at the start position', () => {
+                const match = fragment.match('here is my-text', 8, false);
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('my-text');
+                expect(match?.getStart()).to.equal(8);
+            });
+
+            it('should match when a partial match appears before a full one', () => {
+                const match = fragment.match(
+                    'here is my-prefix followed by my-text',
+                    8,
+                    false
+                );
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('my-text');
+                expect(match?.getStart()).to.equal(30);
+            });
+
+            it('should match when the pattern appears after the start position', () => {
+                const match = fragment.match('here is my-text', 5, false);
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('my-text');
+                expect(match?.getStart()).to.equal(8);
+            });
+
+            it('should return null when the pattern does not appear in the subject', () => {
+                expect(fragment.match('something-else', 0, false)).to.be.null;
+            });
+
+            it('should return null when the only match appears before the start position', () => {
+                expect(fragment.match('here is my-text', 9, false)).to.be.null;
+            });
+        });
+
+        describe('when anchored', () => {
+            it('should match when the pattern appears at the start position', () => {
+                const match = fragment.match('here is my-text', 8, true);
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('my-text');
+                expect(match?.getStart()).to.equal(8);
+            });
+
+            it('should match when a partial match appears before a full one', () => {
+                const match = fragment.match(
+                    'here is my-prefix followed by my-text',
+                    30,
+                    true
+                );
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('my-text');
+                expect(match?.getStart()).to.equal(30);
+            });
+
+            it('should return null when the pattern appears after the start position', () => {
+                const match = fragment.match('here is my-text', 5, true);
+
+                expect(match).to.be.null;
+            });
+
+            it('should return null when the pattern does not appear in the subject', () => {
+                expect(fragment.match('something-else', 0, true)).to.be.null;
+            });
+
+            it('should return null when the only match appears before the start position', () => {
+                expect(fragment.match('here is my-text', 9, true)).to.be.null;
+            });
+        });
+    });
+
+    describe('toString()', () => {
+        it('should return the correct string representation', () => {
+            expect(fragment.toString()).to.equal('my-text');
+        });
+    });
+
+    describe('toStructure()', () => {
+        it('should return the correct structure', () => {
+            expect(fragment.toStructure()).to.deep.equal({
+                type: 'pattern',
+                capturingGroups: [0, 1, 'myGroup', 2],
+                components: [
+                    {
+                        type: 'literal',
+                        chars: 'my-',
+                    },
+                    {
+                        type: 'literal',
+                        chars: 'text',
+                    },
+                ],
+            });
+        });
+    });
+});

--- a/test/unit/Match/Fragment/PossessiveQuantifierFragmentTest.ts
+++ b/test/unit/Match/Fragment/PossessiveQuantifierFragmentTest.ts
@@ -1,0 +1,278 @@
+/*
+ * PCREmu - PCRE emulation for JavaScript.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/pcremu/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/pcremu/raw/master/MIT-LICENSE.txt
+ */
+
+import { expect } from 'chai';
+import CapturingGroupFragment from '../../../../src/Match/Fragment/CapturingGroupFragment';
+import FragmentMatcher from '../../../../src/Match/FragmentMatcher';
+import LiteralFragment from '../../../../src/Match/Fragment/LiteralFragment';
+import NativeFragment from '../../../../src/Match/Fragment/NativeFragment';
+import PossessiveQuantifierFragment from '../../../../src/Match/Fragment/PossessiveQuantifierFragment';
+import QuantifierMatcher from '../../../../src/Match/QuantifierMatcher';
+
+describe('PossessiveQuantifierFragment', () => {
+    let fragment: PossessiveQuantifierFragment;
+    let fragmentMatcher: FragmentMatcher;
+    let quantifierMatcher: QuantifierMatcher;
+
+    beforeEach(() => {
+        fragmentMatcher = new FragmentMatcher();
+        quantifierMatcher = new QuantifierMatcher(fragmentMatcher);
+
+        fragment = new PossessiveQuantifierFragment(
+            quantifierMatcher,
+            new LiteralFragment('my-text'),
+            2,
+            4
+        );
+    });
+
+    describe('match()', () => {
+        describe('when un-anchored', () => {
+            it('should not match when the component appears at the start position once', () => {
+                const match = fragment.match('here is my-text', 8, false);
+
+                expect(match).to.be.null;
+            });
+
+            it('should match when the component appears at the start position twice consecutively', () => {
+                const match = fragment.match(
+                    'here is my-textmy-text',
+                    8,
+                    false
+                );
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('my-textmy-text');
+                expect(match?.getStart()).to.equal(8);
+            });
+
+            it('should match when the component appears at the start position three times consecutively', () => {
+                const match = fragment.match(
+                    'here is my-textmy-textmy-text',
+                    8,
+                    false
+                );
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('my-textmy-textmy-text');
+                expect(match?.getStart()).to.equal(8);
+            });
+
+            it('should match when the component appears at the start position four times consecutively', () => {
+                const match = fragment.match(
+                    'here is my-textmy-textmy-textmy-text',
+                    8,
+                    false
+                );
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal(
+                    'my-textmy-textmy-textmy-text'
+                );
+                expect(match?.getStart()).to.equal(8);
+            });
+
+            it('should not include a fifth occurrence in the match', () => {
+                const match = fragment.match(
+                    'here is my-textmy-textmy-textmy-textmy-text',
+                    8,
+                    false
+                );
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal(
+                    // Only the first four (up to maximumMatches) are matched.
+                    'my-textmy-textmy-textmy-text'
+                );
+                expect(match?.getStart()).to.equal(8);
+            });
+
+            it('should match when the component appears after the start position', () => {
+                const match = fragment.match(
+                    'here is my-textmy-text',
+                    5,
+                    false
+                );
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('my-textmy-text');
+                expect(match?.getStart()).to.equal(8);
+            });
+
+            it('should fail to backtrack inside the most recent occurrence', () => {
+                fragment = new PossessiveQuantifierFragment(
+                    quantifierMatcher,
+                    new CapturingGroupFragment(
+                        fragmentMatcher,
+                        [new NativeFragment('my(?:-text)?')],
+                        12
+                    ),
+                    2,
+                    4
+                );
+
+                const match = fragment.match(
+                    'here is my-textmy-text',
+                    8,
+                    false
+                );
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('my-textmy-text');
+                const backtrackedMatch = match?.backtrack();
+                expect(backtrackedMatch).to.be.null;
+            });
+
+            it('should fail to backtrack while there are more than the minimum number of matches to give up', () => {
+                const match = fragment.match(
+                    'here is my-textmy-textmy-text',
+                    8,
+                    false
+                );
+
+                expect(match).not.to.be.null;
+                const backtrackedMatch = match?.backtrack();
+                expect(backtrackedMatch).to.be.null;
+            });
+
+            it('should return null when the component does not appear in the subject', () => {
+                expect(fragment.match('something-else', 0, false)).to.be.null;
+            });
+
+            it('should return null when the only match appears before the start position', () => {
+                expect(fragment.match('here is my-textmy-text', 9, false)).to.be
+                    .null;
+            });
+        });
+
+        describe('when anchored', () => {
+            it('should not match when the component appears at the start position once', () => {
+                const match = fragment.match('here is my-text', 8, true);
+
+                expect(match).to.be.null;
+            });
+
+            it('should match when the component appears at the start position twice consecutively', () => {
+                const match = fragment.match('here is my-textmy-text', 8, true);
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('my-textmy-text');
+                expect(match?.getStart()).to.equal(8);
+            });
+
+            it('should match when the component appears at the start position three times consecutively', () => {
+                const match = fragment.match(
+                    'here is my-textmy-textmy-text',
+                    8,
+                    true
+                );
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('my-textmy-textmy-text');
+                expect(match?.getStart()).to.equal(8);
+            });
+
+            it('should match when the component appears at the start position four times consecutively', () => {
+                const match = fragment.match(
+                    'here is my-textmy-textmy-textmy-text',
+                    8,
+                    true
+                );
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal(
+                    'my-textmy-textmy-textmy-text'
+                );
+                expect(match?.getStart()).to.equal(8);
+            });
+
+            it('should not include a fifth occurrence in the match', () => {
+                const match = fragment.match(
+                    'here is my-textmy-textmy-textmy-textmy-text',
+                    8,
+                    true
+                );
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal(
+                    // Only the first four (up to maximumMatches) are matched.
+                    'my-textmy-textmy-textmy-text'
+                );
+                expect(match?.getStart()).to.equal(8);
+            });
+
+            it('should return null when the component appears after the start position', () => {
+                const match = fragment.match('here is my-textmy-text', 5, true);
+
+                expect(match).to.be.null;
+            });
+
+            it('should fail to backtrack inside the most recent occurrence', () => {
+                fragment = new PossessiveQuantifierFragment(
+                    quantifierMatcher,
+                    new CapturingGroupFragment(
+                        fragmentMatcher,
+                        [new NativeFragment('my(?:-text)?')],
+                        12
+                    ),
+                    2,
+                    4
+                );
+
+                const match = fragment.match('here is my-textmy-text', 8, true);
+
+                expect(match).not.to.be.null;
+                expect(match?.getCapture()).to.equal('my-textmy-text');
+                const backtrackedMatch = match?.backtrack();
+                expect(backtrackedMatch).to.be.null;
+            });
+
+            it('should fail to backtrack while there are more than the minimum number of matches to give up', () => {
+                const match = fragment.match(
+                    'here is my-textmy-textmy-text',
+                    8,
+                    true
+                );
+
+                expect(match).not.to.be.null;
+                const backtrackedMatch = match?.backtrack();
+                expect(backtrackedMatch).to.be.null;
+            });
+
+            it('should return null when the component does not appear in the subject', () => {
+                expect(fragment.match('something-else', 0, true)).to.be.null;
+            });
+
+            it('should return null when the only match appears before the start position', () => {
+                expect(fragment.match('here is my-textmy-text', 9, true)).to.be
+                    .null;
+            });
+        });
+    });
+
+    describe('toString()', () => {
+        it('should return the correct string representation', () => {
+            expect(fragment.toString()).to.equal('my-text{2,4}+');
+        });
+    });
+
+    describe('toStructure()', () => {
+        it('should return the correct structure', () => {
+            expect(fragment.toStructure()).to.deep.equal({
+                type: 'possessive-quantifier',
+                minimumMatches: 2,
+                maximumMatches: 4,
+                component: {
+                    type: 'literal',
+                    chars: 'my-text',
+                },
+            });
+        });
+    });
+});

--- a/test/unit/ParserTest.ts
+++ b/test/unit/ParserTest.ts
@@ -25,8 +25,10 @@ describe('Parser', () => {
             expect(ast.getFlags()).to.deep.equal({
                 anchored: false,
                 caseless: false,
+                dotAll: false,
                 extended: false,
                 multiline: false,
+                optimise: true,
             });
             expect(ast.getPattern()).to.equal('my.*?regex');
         });
@@ -37,8 +39,10 @@ describe('Parser', () => {
             expect(ast.getFlags()).to.deep.equal({
                 anchored: false,
                 caseless: false,
+                dotAll: false,
                 extended: true,
                 multiline: false,
+                optimise: true,
             });
             expect(ast.getPattern()).to.equal('my.*?regex');
         });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "strict": true,
     "target": "es5"
   },
+  "include": ["./src/**/*"],
   "exclude": [
     "dist",
     "node_modules"


### PR DESCRIPTION
Large refactor to allow full or partial optimisation of PCRE regexes:

- Adds an optimising compiler with two passes.
- Models all supported regex features as `*Fragment` classes, used for any unoptimised parts of a compiled regex.
- Parts of the (or the entire) regex are modelled as `NativeFragment`s, which offers the best performance as native JavaScript `RegExp`s are used as much as possible.